### PR TITLE
Remove page title from _document.js

### DIFF
--- a/renderer/pages/_document.js
+++ b/renderer/pages/_document.js
@@ -25,7 +25,6 @@ class CustomDocument extends Document {
     return (
       <html>
         <Head>
-          <title>OONI Probe</title>
           {this.props.styleTags}
         </Head>
         <body>


### PR DESCRIPTION
Using `<title>` in `pages/_document.js` leads to unexpected results as per https://github.com/zeit/next.js/blob/master/errors/no-document-title.md