### PR TITLE
Remove deprecated prefetch attribute from Link

### DIFF
--- a/renderer/components/Sidebar.js
+++ b/renderer/components/Sidebar.js
@@ -49,7 +49,7 @@ const NavItem = ({href, icon, label, currentUrl}) => {
   const isActive = currentUrl.pathname === href
   return (
     <StyledNavItem isActive={isActive}>
-      <Link href={href} prefetch>
+      <Link href={href}>
         <Flex alignItems='center'>
           <Box>
             {icon}


### PR DESCRIPTION
Next.js 9 automatically prefetches components as they appear in viewport. Refer: https://err.sh/zeit/next.js/prefetch-true-deprecated