### PR TITLE
Upgrade to ooni/probe-cli@v3.0.0-beta.4

### DIFF
--- a/main/utils/paths.js
+++ b/main/utils/paths.js
@@ -52,7 +52,7 @@ const getBinaryDirectory = () => {
 const getBinaryPath = () => {
   const directoryPath = getBinaryDirectory()
   const suffix = getBinarySuffix()
-  return path.join(directoryPath, 'ooni' + suffix)
+  return path.join(directoryPath, 'ooniprobe' + suffix)
 }
 
 const getSSLCertFilePath = () => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.0.0-beta.4",
-  "probeVersion": "3.0.0-beta.3",
+  "probeVersion": "3.0.0-beta.4",
   "main": "main/index.js",
   "license": "MIT",
   "repository": "ooni/probe-desktop",

--- a/scripts/download-bin.js
+++ b/scripts/download-bin.js
@@ -1,7 +1,7 @@
 /* global require */
 
 const { execSync } = require('child_process')
-const { readFileSync, existsSync } = require('fs')
+const { readFileSync } = require('fs')
 const pkgJson = require('../package.json')
 
 const probeVersion = pkgJson['probeVersion']
@@ -9,10 +9,12 @@ const baseURL = `https://github.com/ooni/probe-cli/releases/download/v${probeVer
 const download = () => {
   let checksums = {}
 
+  execSync('mkdir -p bin/')
+
   execSync(`curl -#f -L -o ./bin/ooniprobe_checksums.txt ${baseURL}/ooniprobe_checksums.txt`)
   const checksumsData = readFileSync('./bin/ooniprobe_checksums.txt')
   checksumsData.toString().split('\n').forEach(line => {
-    if (line === "") {
+    if (line === '') {
       return
     }
     const [sum, tarPath] = line.split('  ')


### PR DESCRIPTION
Includes some tweaks to the build script to allow for releases
that contain git tags. Removes support for downloading a CA
bundle, since probe-engine now manages that.

Companion to https://github.com/ooni/probe-cli/pull/65