### PR TITLE
Use show command

### DIFF
--- a/main/actions.js
+++ b/main/actions.js
@@ -85,8 +85,38 @@ const listResults = () => {
   })
 }
 
+const showMeasurement = (msmtID) => {
+  const ooni = new Ooniprobe()
+  let measurement = {}
+
+  return new Promise((resolve, reject) => {
+    ooni.on('data', (data) => {
+      if (data.level == 'error') {
+        reject(data.message)
+      }
+
+      switch(data.fields.type) {
+      case 'measurement_json':
+        measurement = data.fields.measurement_json
+        break
+      default:
+        debug('extra data.fields', data.fields)
+      }
+    })
+
+    ooni
+      .call(['show', msmtID])
+      .then(() => {
+        debug(`showing measurement: ${msmtID}`)
+        resolve(measurement)
+      })
+      .catch(err => reject(err))
+  })
+}
+
 module.exports = {
   listResults,
   listMeasurements,
+  showMeasurement,
   hardReset
 }

--- a/renderer/pages/measurement.js
+++ b/renderer/pages/measurement.js
@@ -11,7 +11,7 @@ import MeasurementContainer from '../components/measurement/MeasurementContainer
 import ErrorView from '../components/ErrorView'
 import LoadingOverlay from '../components/LoadingOverlay'
 
-const debug = require('debug')('ooniprobe-desktop.renderer.pages.results')
+const debug = require('debug')('ooniprobe-desktop.renderer.pages.measurement')
 
 class Measurement extends React.Component {
   constructor(props) {


### PR DESCRIPTION
Integrates the `ooniprobe show` command to fetch raw measurement JSON for a given `measurement_id`.