### PR TITLE
Use the new next path for builds in production

### DIFF
--- a/main/windows/windowURL.js
+++ b/main/windows/windowURL.js
@@ -11,7 +11,7 @@ const windowURL = page => {
   }
   const devPath = `http://localhost:8000/${page}`
   let prodPath = format({
-    pathname: resolve(`renderer/out/${page}/index.html`),
+    pathname: resolve(`renderer/out/${page}.html`),
     protocol: 'file:',
     slashes: true
   })


### PR DESCRIPTION
This fixes the builds having a white page when loading.