### PR TITLE
Handle overflowing test card descriptions 

### DIFF
--- a/main/windows/windowURL.js
+++ b/main/windows/windowURL.js
@@ -11,7 +11,7 @@ const windowURL = page => {
   }
   const devPath = `http://localhost:8000/${page}`
   let prodPath = format({
-    pathname: resolve(`renderer/out/${page}/index.html`),
+    pathname: resolve(`renderer/out/${page}.html`),
     protocol: 'file:',
     slashes: true
   })

--- a/renderer/pages/home.js
+++ b/renderer/pages/home.js
@@ -66,6 +66,11 @@ const ConfigureButton = styled(Button)`
   border: 1px solid ${props => props.theme.colors.white};
 `
 
+const ScrollableBox = styled(Box)`
+  max-height: 150px;
+  overflow: auto;
+`
+
 const FrontCardContent = ({name, description, icon, color, toggleCard, onRun, onConfigure}) => (
   <Box width={1/2} pr={3} pb={3}>
     <Card bg={color} color='white' style={{position: 'relative', height: '250px'}}>
@@ -101,7 +106,9 @@ const BackCardContent = ({name, longDescription, color, toggleCard}) => (
       </TopLeftFloatingButton>
       <CardContent>
         <Heading h={3}>{name}</Heading>
-        {longDescription}
+        <ScrollableBox>
+          {longDescription}
+        </ScrollableBox>
       </CardContent>
     </Card>
   </Box>

--- a/renderer/pages/home.js
+++ b/renderer/pages/home.js
@@ -82,7 +82,7 @@ const FrontCardContent = ({name, description, icon, color, toggleCard, onRun, on
         <BgIcon>
           {icon}
         </BgIcon>
-        <Flex pt={5}>
+        <Flex pt={5} alignItems='center'>
           <Box width={3/4} pr={4}>
             {description}
           </Box>


### PR DESCRIPTION
The descriptions are now in scrollable boxes.
Fixes (not really) #63 (Will close it when a proper solution is implemented)