### PR TITLE
Fix width of Raw Data modal

### DIFF
--- a/renderer/components/measurement/RawDataContainer.js
+++ b/renderer/components/measurement/RawDataContainer.js
@@ -13,7 +13,9 @@ const StyledWrapper = styled(Fixed)`
   overflow-y: scroll;
   background-color: ${props => props.theme.colors.gray1};
   z-index: 2;
-
+  left: 0;
+  right: 0;
+  margin-left: 220px;
   &::-webkit-scrollbar {
     display: none;
   }

--- a/renderer/components/measurement/RawDataContainer.js
+++ b/renderer/components/measurement/RawDataContainer.js
@@ -15,6 +15,7 @@ const StyledWrapper = styled(Fixed)`
   z-index: 2;
   left: 0;
   right: 0;
+  /* Since the sidebar has a higher z-index, this avoids an overlap with it */
   margin-left: 220px;
   &::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
Makes the `Fixed` modal full width. Since the sidebar has a higher `z-index`, we avoid an overlap with it by adding a margin to the left of the modal.

Looks like this now:
![image](https://user-images.githubusercontent.com/700829/68886122-8280a300-06e4-11ea-8684-b0ef29842e5b.png)
