### PR TITLE
Add link to risks doc in onboarding screen

### DIFF
--- a/renderer/components/ExternalLink.js
+++ b/renderer/components/ExternalLink.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'ooni-components'
+
+import { openInBrowser } from './utils'
+
+const ExternalLink = ({href, color = 'blue5', children}) => {
+  return (
+    <Link color={color} href={href} onClick={(e) => openInBrowser(href, e)}>
+      {children}
+    </Link>
+  )
+}
+
+ExternalLink.propTypes = {
+  href: PropTypes.string.isRequired,
+  color: PropTypes.string,
+  children: PropTypes.node
+}
+
+export default ExternalLink

--- a/renderer/components/ExternalLink.js
+++ b/renderer/components/ExternalLink.js
@@ -1,14 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'ooni-components'
+import styled from 'styled-components'
 
 import { openInBrowser } from './utils'
 
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  &:hover {
+    color: ${props => props.theme.colors.gray3};
+  }
+`
+
 const ExternalLink = ({href, color = 'blue5', children}) => {
   return (
-    <Link color={color} href={href} onClick={(e) => openInBrowser(href, e)}>
+    <StyledLink color={color} href={href} onClick={(e) => openInBrowser(href, e)}>
       {children}
-    </Link>
+    </StyledLink>
   )
 }
 

--- a/renderer/components/FormattedMarkdownMessage.js
+++ b/renderer/components/FormattedMarkdownMessage.js
@@ -1,37 +1,12 @@
-/* global require */
 import React from 'react'
-import PropTypes from 'prop-types'
 import { useIntl } from 'react-intl'
-import styled from 'styled-components'
 import remark from 'remark'
 import reactRenderer from 'remark-react'
 
-import { openInBrowser } from './utils'
-
-const StyledLink = styled.a`
-  color: ${props => props.theme.colors.blue5};
-  text-decoration: none;
-
-  &:hover {
-    color: ${props => props.theme.colors.blue3};
-  }
-`
-
-const OpenLinkInBrowser = ({href, children}) => {
-  return (
-    <StyledLink href={href} onClick={(e) => openInBrowser(href, e)}>
-      {children}
-    </StyledLink>
-  )
-}
-
-OpenLinkInBrowser.propTypes = {
-  href: PropTypes.string.isRequired,
-  children: PropTypes.node
-}
+import ExternalLink from './ExternalLink'
 
 const remarkReactComponents = {
-  a: OpenLinkInBrowser
+  a: ExternalLink
 }
 
 const FormattedMarkdownMessage = ({ id, defaultMessage, values, description }) => {

--- a/renderer/components/onboard/Sections.js
+++ b/renderer/components/onboard/Sections.js
@@ -104,7 +104,7 @@ const SectionThingsToKnow = ({onNext, quizActive, quizComplete, toggleQuiz, onQu
         </Button>
       </Box>
       <Box mt={3} mx='auto'>
-        <NLink href='https://ooni.io/about/risks/' passHref>
+        <NLink href='https://ooni.org/about/risks/' passHref>
           <ExternalLink color='white'>Learn More</ExternalLink>
         </NLink>
       </Box>

--- a/renderer/components/onboard/Sections.js
+++ b/renderer/components/onboard/Sections.js
@@ -27,8 +27,10 @@ import {
   Flex,
   Heading
 } from 'ooni-components'
+import NLink from 'next/link'
 
 import FormattedMarkdownMessage from '../FormattedMarkdownMessage'
+import ExternalLink from '../ExternalLink'
 import Stepper from './Stepper'
 import QuizSteps from './QuizSteps'
 
@@ -100,6 +102,11 @@ const SectionThingsToKnow = ({onNext, quizActive, quizComplete, toggleQuiz, onQu
         <Button inverted onClick={quizComplete ? onNext : toggleQuiz}>
           <FormattedMessage id="Onboarding.ThingsToKnow.Button" />
         </Button>
+      </Box>
+      <Box mt={3} mx='auto'>
+        <NLink href='https://ooni.io/about/risks/' passHref>
+          <ExternalLink color='white'>Learn More</ExternalLink>
+        </NLink>
       </Box>
     </Flex>
   </div>


### PR DESCRIPTION
Fixes #60 

Looks like this. Do we want to remove the underline from the link's default styling?

![image](https://user-images.githubusercontent.com/700829/70001376-206cce00-152b-11ea-96ac-194116b5fdb8.png)
