### PR TITLE
Fix alignment of result list row summaries

### DIFF
--- a/renderer/components/test-results/ResultRow.js
+++ b/renderer/components/test-results/ResultRow.js
@@ -54,50 +54,57 @@ const VerticalCenter = ({children}) => {
     </Flex>
   )
 }
+
 const SummaryContainer = styled(Flex)`
-  padding-left: 20px;
-  padding-top: 20px;
+  height: 100%;
 `
 
-const WebsitesSummary = ({anomalyCount, totalCount}) => {
-  return <SummaryContainer flexWrap='wrap'>
-    <Box width={1}>
-      <Text color={anomalyCount > 0 ? theme.colors.red8 : theme.colors.black}>
-        <MdClear /><FormattedMessage id='TestResults.Overview.Websites.Blocked.Plural' values={{ Count: anomalyCount }}/>
-      </Text>
-    </Box>
-    <Box width={1}>
-      <Text>
-        <MdWeb /><FormattedMessage id='TestResults.Overview.Websites.Tested.Plural' values={{ Count: totalCount }} />
-      </Text>
-    </Box>
-  </SummaryContainer>
+SummaryContainer.defaultProps = {
+  flexDirection: 'column',
+  justifyContent: 'center',
+  width: 2/3,
+  mx: 'auto'
 }
 
-const IMSummary = ({anomalyCount, totalCount}) => {
-  return <SummaryContainer flexWrap='wrap'>
-    <Box width={1}>
-      <Text color={anomalyCount > 0 ? theme.colors.red8 : theme.colors.black}>
-        <MdClear /><FormattedMessage id='TestResults.Overview.InstantMessaging.Blocked.Plural' values={{ Count: anomalyCount }}/>
-      </Text>
+const WebsitesSummary = ({anomalyCount, totalCount}) => (
+  <SummaryContainer>
+    <Box>
+      <Flex color={anomalyCount > 0 ? theme.colors.red8 : theme.colors.black} alignItems='center'>
+        <MdClear />&nbsp;<FormattedMessage id='TestResults.Overview.Websites.Blocked.Plural' values={{ Count: anomalyCount }}/>
+      </Flex>
     </Box>
-    <Box width={1}>
-      <Text>
-        <MdDone /> <FormattedMessage id='TestResults.Overview.InstantMessaging.Available.Plural' values={{ Count: totalCount }} />
-      </Text>
+    <Box>
+      <Flex alignItems='center'>
+        <MdWeb />&nbsp;<FormattedMessage id='TestResults.Overview.Websites.Tested.Plural' values={{ Count: totalCount }} />
+      </Flex>
+    </Box>
+  </SummaryContainer>
+)
+
+const IMSummary = ({anomalyCount, totalCount}) => {
+  return <SummaryContainer>
+    <Box>
+      <Flex color={anomalyCount > 0 ? theme.colors.red8 : theme.colors.black} alignItems='center'>
+        <MdClear />&nbsp;<FormattedMessage id='TestResults.Overview.InstantMessaging.Blocked.Plural' values={{ Count: anomalyCount }}/>
+      </Flex>
+    </Box>
+    <Box>
+      <Flex alignItems='center'>
+        <MdDone />&nbsp;<FormattedMessage id='TestResults.Overview.InstantMessaging.Available.Plural' values={{ Count: totalCount }} />
+      </Flex>
     </Box>
   </SummaryContainer>
 }
 
 const PerformanceSummary = ({testKeys}) => {
-  return <SummaryContainer flexWrap='wrap'>
-    <Box width={1/2}>
+  return <SummaryContainer>
+    <Box>
       <DownloadSpeed bits={testKeys['download']} />
     </Box>
-    <Box width={1/2}>
+    <Box>
       <VideoQuality bitrate={testKeys['median_bitrate']} />
     </Box>
-    <Box width={1/2}>
+    <Box>
       <UploadSpeed bits={testKeys['upload']} />
     </Box>
   </SummaryContainer>
@@ -111,15 +118,15 @@ const MiddelboxSummary = ({anomalyCount}) => {
     msgID = 'TestResults.Summary.Middleboxes.Hero.Found'
   }
 
-  return <VerticalCenter>
+  return <SummaryContainer>
     <FormattedMessage id={msgID} />
-  </VerticalCenter>
+  </SummaryContainer>
 }
 
 const SummaryError = () => {
-  return <VerticalCenter>
+  return <SummaryContainer>
     <Text color={theme.colors.red8}>Error</Text>
-  </VerticalCenter>
+  </SummaryContainer>
 }
 
 const summaryMap = {
@@ -219,16 +226,16 @@ class ResultRow extends React.Component {
           <Box pr={2} width={4/16}>
             {this.renderIcon()}
           </Box>
-          <Box width={3/16} h={1}>
+          <Box width={3/16}>
             {this.renderNetwork()}
           </Box>
-          <Box pr={3/16}>
+          <Box width={3/16}>
             {this.renderDate()}
           </Box>
-          <Box width={4/16} >
+          <Box width={5/16} >
             {this.renderTestKeys()}
           </Box>
-          <Box width={1/16} style={{marginLeft: 'auto'}}>
+          <Box width={1/16} ml='auto'>
             <VerticalCenter>
               <RightArrowStyled />
             </VerticalCenter>


### PR DESCRIPTION
Fix alignment of icons and labels in Result list rows. Looks like this now:

![image](https://user-images.githubusercontent.com/700829/70218011-3a1b3a80-1710-11ea-9cd3-62cf6b14d23a.png)
