### PR TITLE
Enable draggability on header to drag windows on MacOS

### DIFF
--- a/renderer/components/measurement/MeasurementContainer.js
+++ b/renderer/components/measurement/MeasurementContainer.js
@@ -75,6 +75,8 @@ const StickyHeader = styled(Box)`
   position: sticky;
   top: 0px;
   width: 100%;
+  /* This makes it possible to drag the window around from the side bar */
+  -webkit-app-region: drag;
 `
 
 const Hero = ({


### PR DESCRIPTION
Fixes ooni/probe#1033
The zIndex issue was already solved.