### PR TITLE
Revert to default colors for links on hover

### DIFF
--- a/renderer/components/ExternalLink.js
+++ b/renderer/components/ExternalLink.js
@@ -1,22 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'ooni-components'
-import styled from 'styled-components'
 
 import { openInBrowser } from './utils'
 
-const StyledLink = styled(Link)`
-  text-decoration: none;
-  &:hover {
-    color: ${props => props.theme.colors.gray3};
-  }
-`
-
 const ExternalLink = ({href, color = 'blue5', children}) => {
   return (
-    <StyledLink color={color} href={href} onClick={(e) => openInBrowser(href, e)}>
+    <Link color={color} href={href} onClick={(e) => openInBrowser(href, e)}>
       {children}
-    </StyledLink>
+    </Link>
   )
 }
 

--- a/renderer/components/onboard/Sections.js
+++ b/renderer/components/onboard/Sections.js
@@ -105,7 +105,7 @@ const SectionThingsToKnow = ({onNext, quizActive, quizComplete, toggleQuiz, onQu
       </Box>
       <Box mt={3} mx='auto'>
         <NLink href='https://ooni.org/about/risks/' passHref>
-          <ExternalLink color='white'>Learn More</ExternalLink>
+          <ExternalLink color='gray3'>Learn More</ExternalLink>
         </NLink>
       </Box>
     </Flex>


### PR DESCRIPTION
The gray on hover was added specifically for the link in the onboarding (2nd) screen which was white text on dark background. The `Link` component in `ooni-components` was updated later to use a themed blue as default color. It uses CSS `filter: brightness();` for hover, which doesn't work very well on white text, hence the [change to gray](https://github.com/ooni/probe-desktop/pull/111/files#diff-51c5bb6e90b2d6ecdaea6ca065fec954R108).