### PR TITLE
Fix alignment of data usage stats on results screen

### DIFF
--- a/renderer/components/HumanFilesize.js
+++ b/renderer/components/HumanFilesize.js
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import humanize from 'humanize'
 
 import {
-  Box
+  Flex
 } from 'ooni-components'
 
 const FileUnit = styled.span`
@@ -17,20 +17,15 @@ const FileAmount = styled.span`
   font-weight: 300;
 `
 
-const StyledHumanFilesize = styled(Box)`
-  padding: 0px;
-  text-align: center;
-`
-
 const HumanFilesize = ({icon, size, fontSize}) => {
   const human = humanize.filesize(size)
   const [amount, unit] = human.split(' ')
   return (
-    <StyledHumanFilesize>
+    <Flex alignItems='baseline'>
       {icon}
       <FileAmount fontSize={fontSize}>{amount}</FileAmount>
       <FileUnit fontSize={fontSize}>{unit}</FileUnit>
-    </StyledHumanFilesize>
+    </Flex>
   )
 }
 
@@ -41,7 +36,7 @@ HumanFilesize.propTypes = {
 }
 
 HumanFilesize.defaultProps = {
-  fontSize: 24
+  fontSize: 36
 }
 
 export default HumanFilesize

--- a/renderer/components/test-results/TestResultsContainer.js
+++ b/renderer/components/test-results/TestResultsContainer.js
@@ -35,10 +35,10 @@ const DataUsage = ({ dataUsage }) => {
       </LabelBox>
       <Flex flexDirection='column'>
         <Box>
-          <HumanFilesize icon={<MdArrowUpward size={28} />} size={dataUsage.up*1024} />
+          <HumanFilesize fontSize={26} icon={<MdArrowUpward size={22} />} size={dataUsage.up*1024} />
         </Box>
         <Box>
-          <HumanFilesize icon={<MdArrowDownward size={28} />} size={dataUsage.down*1024} />
+          <HumanFilesize fontSize={26} icon={<MdArrowDownward size={22} />} size={dataUsage.down*1024} />
         </Box>
       </Flex>
     </Flex>

--- a/renderer/components/test-results/TestResultsContainer.js
+++ b/renderer/components/test-results/TestResultsContainer.js
@@ -38,16 +38,14 @@ const DataUsage = ({dataUsage}) => {
       <LabelBox>
         <FormattedMessage id='TestResults.Overview.Hero.DataUsage' />
       </LabelBox>
-      <Box>
-        <Flex>
-          <Box width={1/2}>
-            <HumanFilesize icon={<MdArrowUpward size={20}/>} size={dataUsage.up*1024} />
-          </Box>
-          <Box width={1/2}>
-            <HumanFilesize icon={<MdArrowDownward size={20} />} size={dataUsage.down*1024} />
-          </Box>
-        </Flex>
-      </Box>
+      <Flex alignItems='center' justifyContent='space-around'>
+        <Box>
+          <HumanFilesize icon={<MdArrowUpward size={20}/>} size={dataUsage.up*1024} />
+        </Box>
+        <Box>
+          <HumanFilesize icon={<MdArrowDownward size={20} />} size={dataUsage.down*1024} />
+        </Box>
+      </Flex>
     </Flex>
   )
 }
@@ -72,19 +70,19 @@ const ResultsHeader = ({testCount, networkCount, dataUsage}) => {
     <StyledResultsHeader>
       <Container>
         <Flex>
-          <Box width={1/3}>
+          <Box width={1/4}>
             <StatBox
               label={<FormattedMessage id='TestResults.Overview.Hero.Tests' />}
               value={testCount} />
           </Box>
           <VerticalDivider />
-          <Box width={1/3}>
+          <Box width={1/4}>
             <StatBox
               label={<FormattedMessage id='TestResults.Overview.Hero.Networks' />}
               value={networkCount} />
           </Box>
           <VerticalDivider />
-          <Box width={1/3}>
+          <Box width={2/4}>
             <DataUsage dataUsage={dataUsage} />
           </Box>
         </Flex>

--- a/renderer/components/test-results/TestResultsContainer.js
+++ b/renderer/components/test-results/TestResultsContainer.js
@@ -24,13 +24,8 @@ import {
 } from 'ooni-components'
 import { FormattedMessage } from 'react-intl'
 
-import StatBox from '../to-migrate/StatBox'
+import StatBox, { LabelBox } from '../to-migrate/StatBox'
 import VerticalDivider from '../to-migrate/VerticalDivider'
-
-const LabelBox= styled(Box)`
-  font-size: 12px;
-  text-align: center;
-`
 
 const DataUsage = ({dataUsage}) => {
   return (

--- a/renderer/components/test-results/TestResultsContainer.js
+++ b/renderer/components/test-results/TestResultsContainer.js
@@ -27,18 +27,18 @@ import { FormattedMessage } from 'react-intl'
 import StatBox, { LabelBox } from '../to-migrate/StatBox'
 import VerticalDivider from '../to-migrate/VerticalDivider'
 
-const DataUsage = ({dataUsage}) => {
+const DataUsage = ({ dataUsage }) => {
   return (
-    <Flex flexDirection='column'>
+    <Flex flexDirection='column' alignItems='center'>
       <LabelBox>
         <FormattedMessage id='TestResults.Overview.Hero.DataUsage' />
       </LabelBox>
-      <Flex alignItems='center' justifyContent='space-around'>
+      <Flex flexDirection='column'>
         <Box>
-          <HumanFilesize icon={<MdArrowUpward size={20}/>} size={dataUsage.up*1024} />
+          <HumanFilesize icon={<MdArrowUpward size={28} />} size={dataUsage.up*1024} />
         </Box>
         <Box>
-          <HumanFilesize icon={<MdArrowDownward size={20} />} size={dataUsage.down*1024} />
+          <HumanFilesize icon={<MdArrowDownward size={28} />} size={dataUsage.down*1024} />
         </Box>
       </Flex>
     </Flex>
@@ -65,19 +65,19 @@ const ResultsHeader = ({testCount, networkCount, dataUsage}) => {
     <StyledResultsHeader>
       <Container>
         <Flex>
-          <Box width={1/4}>
+          <Box width={1/3}>
             <StatBox
               label={<FormattedMessage id='TestResults.Overview.Hero.Tests' />}
               value={testCount} />
           </Box>
           <VerticalDivider />
-          <Box width={1/4}>
+          <Box width={1/3}>
             <StatBox
               label={<FormattedMessage id='TestResults.Overview.Hero.Networks' />}
               value={networkCount} />
           </Box>
           <VerticalDivider />
-          <Box width={2/4}>
+          <Box width={1/3}>
             <DataUsage dataUsage={dataUsage} />
           </Box>
         </Flex>

--- a/renderer/components/to-migrate/StatBox.js
+++ b/renderer/components/to-migrate/StatBox.js
@@ -13,13 +13,13 @@ export const LabelBox= styled(Box)`
 `
 
 const ValueBox = styled(Box)`
-  font-size: 36px;
+  font-size: 60px;
   font-weight: 300;
   text-align: center;
 `
 
 const StatBox = ({value, label, unit}) => (
-  <Flex flexDirection='column'>
+  <Flex flexDirection='column' justifyContent='space-between' style={{ height: '100%' }}>
     {label && <LabelBox>
       {label}
     </LabelBox>}

--- a/renderer/components/to-migrate/StatBox.js
+++ b/renderer/components/to-migrate/StatBox.js
@@ -7,7 +7,7 @@ import {
   Box
 } from 'ooni-components'
 
-const LabelBox= styled(Box)`
+export const LabelBox= styled(Box)`
   font-size: 12px;
   text-align: center;
 `

--- a/renderer/components/to-migrate/StatBox.js
+++ b/renderer/components/to-migrate/StatBox.js
@@ -13,13 +13,13 @@ export const LabelBox= styled(Box)`
 `
 
 const ValueBox = styled(Box)`
-  font-size: 60px;
+  font-size: 36px;
   font-weight: 300;
   text-align: center;
 `
 
 const StatBox = ({value, label, unit}) => (
-  <Flex flexDirection='column' justifyContent='space-between' style={{ height: '100%' }}>
+  <Flex flexDirection='column' justifyContent='space-around' style={{ height: '100%' }}>
     {label && <LabelBox>
       {label}
     </LabelBox>}


### PR DESCRIPTION
Fixes ooni/probe#1045

Had to make some changes to layout to accommodate the larger data usage stats component. Looks like this now:
![image](https://user-images.githubusercontent.com/700829/76924863-0f638500-68ae-11ea-91f6-21ddbeb820cd.png)
