### PR TITLE
Log to Sentry when autoUpdater thrown an error

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -123,6 +123,7 @@ autoUpdater.on('update-not-available', () => {
 })
 autoUpdater.on('error', err => {
   sendStatusToWindow('Error in auto-updater. ' + err)
+  Sentry.captureException(err)
 })
 autoUpdater.on('download-progress', progressObj => {
   let log_message = 'Download speed: ' + progressObj.bytesPerSecond

--- a/main/index.js
+++ b/main/index.js
@@ -123,7 +123,10 @@ autoUpdater.on('update-not-available', () => {
 })
 autoUpdater.on('error', err => {
   sendStatusToWindow('Error in auto-updater. ' + err)
-  Sentry.captureException(err)
+  Sentry.withScope((scope) => {
+    scope.setTag('context', 'auto-updater')
+    Sentry.captureException(err)
+  })
 })
 autoUpdater.on('download-progress', progressObj => {
   let log_message = 'Download speed: ' + progressObj.bytesPerSecond


### PR DESCRIPTION
Fixes ooni/probe#1068

When `electron-updater` throws an error, we log it to Sentry in the `error` event handler.