### PR TITLE
Use ndt7

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.0.0-rc.6",
-  "probeVersion": "3.0.0-rc.11",
+  "probeVersion": "3.0.0-rc.13",
   "main": "main/index.js",
   "license": "MIT",
   "repository": "ooni/probe-desktop",

--- a/renderer/components/measurement/MeasurementContainer.js
+++ b/renderer/components/measurement/MeasurementContainer.js
@@ -31,6 +31,7 @@ import FullHeightFlex from '../FullHeightFlex'
 import MethodologyButton from './MethodologyButton'
 import ExplorerURLButton from './ExplorerURLButton'
 import RawDataContainer from './RawDataContainer'
+import { useRawData } from '../useRawData'
 import colorMap from '../colorMap'
 
 const detailsMap = {
@@ -141,7 +142,7 @@ MeasurementDetailContainer.propTypes = {
   measurement: PropTypes.object
 }
 
-const MeasurementContainer = ({measurement, isAnomaly, rawData}) => {
+const MeasurementContainer = ({ measurement, isAnomaly }) => {
   const testName = measurement.test_name
   const startTime = measurement.start_time
   const networkName = measurement.network_name
@@ -149,6 +150,7 @@ const MeasurementContainer = ({measurement, isAnomaly, rawData}) => {
   const runtime = measurement.runtime
 
   const [rawDataOpen, setRawDataOpen] = useState(false)
+  const { rawData } = useRawData()
 
   // anomaly-ness based backgaround color, in case nettest doesn't send
   // an override in `heroBG`

--- a/renderer/components/nettests/circumvention/Tor.js
+++ b/renderer/components/nettests/circumvention/Tor.js
@@ -83,7 +83,7 @@ const NameCell = ({ children }) => {
 }
 
 NameCell.propTypes = {
-  children: PropTypes.element.isRequired
+  children: PropTypes.string.isRequired
 }
 
 const Table = ({ columns, data }) => {

--- a/renderer/components/nettests/circumvention/Tor.js
+++ b/renderer/components/nettests/circumvention/Tor.js
@@ -11,6 +11,7 @@ import { useClipboard } from 'use-clipboard-copy'
 import colorMap from '../../colorMap'
 import StatusBox from '../../measurement/StatusBox'
 import FormattedMarkdownMessage from '../../FormattedMarkdownMessage'
+import { useRawData } from '../../useRawData'
 
 // TODO Should check if it helps to convert these into styled components and
 // render them instead of the native <table> <td> <tr> elements
@@ -129,13 +130,11 @@ const Table = ({ columns, data }) => {
         {rows.map((row) => {
           prepareRow(row)
           return (
-            <React.Fragment>
-              <tr {...row.getRowProps()}>
-                {row.cells.map(cell => {
-                  return <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
-                })}
-              </tr>
-            </React.Fragment>
+            <tr {...row.getRowProps()}>
+              {row.cells.map(cell => {
+                return <td {...cell.getCellProps()}>{cell.render('Cell')}</td>
+              })}
+            </tr>
           )}
         )}
       </tbody>
@@ -169,6 +168,7 @@ ConnectionStatusCell.propTypes = {
 
 const Tor = ({measurement, isAnomaly, render}) => {
   const testKeys = JSON.parse(measurement.test_keys)
+
   const {
     or_port_accessible,
     or_port_total,
@@ -178,15 +178,15 @@ const Tor = ({measurement, isAnomaly, render}) => {
     obfs4_total,
     dir_port_accessible,
     dir_port_total,
-    targets = {}
   } = testKeys
+
   const heroTitle = isAnomaly ? (
     <FormattedMessage id='TestResults.Details.Circumvention.Tor.Blocked.Hero.Title' />
   ) : (
     <FormattedMessage id='TestResults.Details.Circumvention.Tor.Reachable.Hero.Title' />
   )
 
-  const statusColumnSort = (rowA, rowB, columnId, desc) => {
+  const statusColumnSort = (rowA, rowB, desc) => {
     const sortMap = {
       na: 0,
       nullValue: 1,
@@ -243,30 +243,36 @@ const Tor = ({measurement, isAnomaly, render}) => {
     }
   ], [])
 
-  const data = useMemo(() => (
-    Object.keys(targets).map(target => {
-      // Connection Status values
-      // false: Didn't run (N/A)
-      // null: No failure a.k.a success
-      // string: Failure with error string
-      let connectStatus = false, handshakeStatus = false
-      if (targets[target].summary.connect) {
-        connectStatus = targets[target].summary.connect.failure
-      }
+  // Targets data is available only in the raw measurement data JSON
+  const { rawData } = useRawData()
 
-      if (targets[target].summary.handshake) {
-        handshakeStatus = targets[target].summary.handshake.failure
-      }
+  const data = useMemo(() => {
+    const targets = rawData ? rawData.test_keys.targets : {}
+    return (
+      Object.keys(targets).map(target => {
+        // Connection Status values
+        // false: Didn't run (N/A)
+        // null: No failure a.k.a success
+        // string: Failure with error string
+        let connectStatus = false, handshakeStatus = false
+        if (targets[target].summary.connect) {
+          connectStatus = targets[target].summary.connect.failure
+        }
 
-      return {
-        name: targets[target].target_name || target,
-        address: targets[target].target_address,
-        type: targets[target].target_protocol,
-        connect: connectStatus,
-        handshake: handshakeStatus
-      }
-    })
-  ), [targets])
+        if (targets[target].summary.handshake) {
+          handshakeStatus = targets[target].summary.handshake.failure
+        }
+
+        return {
+          name: targets[target].target_name || target,
+          address: targets[target].target_address,
+          type: targets[target].target_protocol,
+          connect: connectStatus,
+          handshake: handshakeStatus
+        }
+      })
+    )
+  }, [rawData])
 
   const TorDetails = () => (
     <Box width={1}>

--- a/renderer/components/result/ResultContainer.js
+++ b/renderer/components/result/ResultContainer.js
@@ -44,13 +44,13 @@ const ResultOverviewContainer = styled.div`
 const overviewShape = PropTypes.shape({
   countryCode: PropTypes.string.isRequired,
   networkName: PropTypes.string.isRequired,
-  asn: PropTypes.string.isRequired,
+  asn: PropTypes.number.isRequired,
   anomalyCount: PropTypes.number.isRequired,
   totalCount: PropTypes.number.isRequired,
   dataUsageUp: PropTypes.number.isRequired,
   dataUsageDown: PropTypes.number.isRequired,
   runtime: PropTypes.number.isRequired,
-  startTime: PropTypes.object
+  startTime: PropTypes.string
 })
 
 // XXX groupName is also passed in
@@ -185,7 +185,7 @@ const mapOverviewProps = (rows, summary) => {
       runtime: summary.total_runtime || 0,
       networkName: msmt.network_name || '',
       countryCode: msmt.network_country_code || '',
-      asn: msmt.asn || '',
+      asn: msmt.asn || 0,
     }
   }
 }

--- a/renderer/components/useRawData.js
+++ b/renderer/components/useRawData.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { useRouter } from 'next/router'
+import electron from 'electron'
+const debug = require('debug')('ooniprobe-desktop.renderer.components.hooks.useRawData')
+import Raven from 'raven-js'
+
+export const useRawData = () => {
+  const [rawData, setRawData] = React.useState(null)
+  const [error, setError] = React.useState(null)
+  const { query } = useRouter()
+  const remote = electron.remote
+  const { showMeasurement } = remote.require('./actions')
+
+  React.useEffect(() => {
+    showMeasurement(query.measurementID).then(measurement => {
+      setRawData(measurement)
+    }).catch(err => {
+      Raven.captureException(err, {extra: {scope: 'renderer.showMeasurement'}})
+      debug('error triggered', err)
+      setError(error)
+    })
+  }, [])
+  return { rawData, error }
+}

--- a/renderer/next.config.js
+++ b/renderer/next.config.js
@@ -35,7 +35,7 @@ module.exports = withSourceMaps(withCSS({
       '/home': { page: '/home' },
       '/test-results': { page: '/test-results' },
       '/result': { page: '/result', query: { resultID: null } },
-      '/measurement': { page: '/measurement', query: { resultID: null, measurementID: null } },
+      '/measurement': { page: '/measurement', query: { resultID: null, measurementID: null, isAnomaly: null } },
       '/settings': { page: '/settings' },
       '/onboard': { page: '/onboard' }
     }

--- a/renderer/pages/measurement.js
+++ b/renderer/pages/measurement.js
@@ -85,7 +85,6 @@ class Measurement extends React.Component {
 
   componentDidMount() {
     this.loadData()
-    this.loadRawData()
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
Fixes ooni/probe#1040

Didn't have to change anything in `NDT.js`. Just had to fallback to using test_keys from `ooniprobe list <id>` output instead of using the one from the raw measurement. This was earlier done to render the table in the Tor msmt details. Now reverted and uses another approach.