### PR TITLE
Set software name and version to desktop

### DIFF
--- a/main/utils/ooni/ooniprobe.js
+++ b/main/utils/ooni/ooniprobe.js
@@ -79,8 +79,12 @@ class Ooniprobe extends EventEmitter {
             console.log('failed to determine the home shortpath. Things will break with user homes which contain non-ascii characters.')
           }
         }
-
-        argv = ['--batch'].concat(argv)
+        const fixedArgs = [
+          '--batch',
+          `--software-name=${process.env.npm_package_name}`,
+          `--software-version=${process.env.npm_package_version}`
+        ]
+        argv = fixedArgs.concat(argv)
 
         log.info('running', binPath, argv, options)
         self.ooni = childProcess.spawn(binPath, argv, options)


### PR DESCRIPTION
Fixes ooni/probe#1079

Uses `name` and `version` from `package.json`

![ - 4](https://user-images.githubusercontent.com/700829/78772883-6c5bd380-7960-11ea-9af6-72d75c776a62.png)
