### PR TITLE
Font size jump

### DIFF
--- a/renderer/components/Sidebar.js
+++ b/renderer/components/Sidebar.js
@@ -14,6 +14,7 @@ import { MdWeb, MdHistory } from 'react-icons/md'
 import { FaCog } from 'react-icons/fa'
 
 import ExternalLink from './ExternalLink'
+import { version } from '../../package.json'
 
 const StyledNavItem = styled.div`
   position: relative;
@@ -126,7 +127,7 @@ export const Sidebar = ({children, router}) => (
         </Box>
         <Box mb={2}>
           <Text fontSize={12} textAlign='right' color='gray5'>
-            {process.env.npm_package_version}
+            {version}
           </Text>
         </Box>
       </Box>

--- a/renderer/pages/home.js
+++ b/renderer/pages/home.js
@@ -81,7 +81,7 @@ const FrontCardContent = ({
       <CardContent>
         <Flex flexDirection='column' justifyContent='space-between' style={{ height: '200px'}}>
           <Text fontSize={4} fontWeight={300} m={0}>{name}</Text>
-          <Text fontSize={1}>
+          <Text fontSize={1} as='div'>
             {description}
           </Text>
           <BgIcon>{icon}</BgIcon>

--- a/renderer/pages/home.js
+++ b/renderer/pages/home.js
@@ -40,17 +40,6 @@ const TopLeftFloatingButton = styled.div`
   cursor: pointer;
 `
 
-const ConfigureButton = styled(Button)`
-  font-size: 12px;
-  border-radius: 20px;
-  height: 25px;
-  line-height: 1;
-  padding-left: 15px;
-  padding-right: 15px;
-  text-transform: none;
-  border: 1px solid ${props => props.theme.colors.white};
-`
-
 const ScrollableBox = styled(Box)`
   max-height: 150px;
   overflow: auto;
@@ -63,8 +52,7 @@ const FrontCardContent = ({
   icon,
   color,
   toggleCard,
-  onRun,
-  onConfigure
+  onRun
 }) => (
   <Box width={1 / 2} pr={3} pb={3}>
     <Card
@@ -156,7 +144,6 @@ class Home extends React.Component {
       runDone: true,
       stopping: false
     }
-    this.onConfigure = this.onConfigure.bind(this)
     this.onRun = this.onRun.bind(this)
     this.onMessage = this.onMessage.bind(this)
     this.onKill = this.onKill.bind(this)
@@ -198,12 +185,6 @@ class Home extends React.Component {
       break
     default:
       break
-    }
-  }
-
-  onConfigure(groupName) {
-    return () => {
-      console.log('configuring', groupName)
     }
   }
 
@@ -281,7 +262,6 @@ class Home extends React.Component {
             {testList.map((t, idx) => (
               <RunTestCard
                 onRun={this.onRun(t.key)}
-                onConfigure={this.onConfigure(t.key)}
                 key={idx}
                 id={t.key}
                 {...t}


### PR DESCRIPTION
Fixes ooni/probe#1103

The fix was arrived after observing the DOM when using `<Text>` is used to wrap the `description` value which is generated by `FormattedMarkdownMessage`. When used as is `Text` component renders a `<p> ` tag which would then contain another `<p>` element rendered by `FormattedMarkdownMessage`. When rendered on server-side this somehow gets printed as
```
<p fontSizeApplied> // rendered by <Text />
</p>
<p> // rendered by <FormattedMarkdownMessage />
  description
</p>
```
instead of
```
<p fontSizeApplied> <p> description text </p> </p>
```
which works when `<Text>` is rendered as a `<div>`

Also fixes the disappearing version label in the sidebar when client side JS gets activated.