### PR TITLE
Fix about window problems

### DIFF
--- a/main/index.js
+++ b/main/index.js
@@ -76,7 +76,7 @@ const editMenu = {
 let menuTemplate = [
   {
     label: app.name,
-    submenu: [{ label: 'About OONI Probe', click: () => openAboutWindow() }]
+    submenu: [{ label: 'About OONI Probe', click: () => openAboutWindow(true) }]
   },
   editMenu
 ]

--- a/main/windows/aboutWindow.js
+++ b/main/windows/aboutWindow.js
@@ -23,8 +23,10 @@ const aboutWindow = () => {
 }
 
 const openAboutWindow = (getFocus) => {
-  if (window !== null && getFocus) {
-    window.focus()
+  if (window !== null) {
+    if (getFocus) {
+      window.focus()
+    }
     return window
   }
 
@@ -35,7 +37,11 @@ const openAboutWindow = (getFocus) => {
   })
 
   window.once('ready-to-show', () => {
-    window.show()
+    if (getFocus) {
+      window.show()
+    } else {
+      window.showInactive()
+    }
   })
   window.setMenu(null)
 

--- a/renderer/pages/about.js
+++ b/renderer/pages/about.js
@@ -93,7 +93,7 @@ class About extends React.Component {
 
   onUpdateMessage(event, text) {
     this.setState({
-      updateMessages: [...this.state.updateMessages, text]
+      updateMessage: text
     })
   }
   onUpdateProgress(event, progressObj) {


### PR DESCRIPTION
Fixes ooni/probe#1122

The `autoUpdater` system use the about window to show updates. The recent changes to manage focus of about window introduced a bug where duplicate windows were being created when `getFocus === false`. This is fixed in this PR.

Another change added here is to not focus the about window every time it is referenced. It still launches the window in the background, which I think is only better than popping it up to the user.

Maybe we should decouple the about window and the updater log view.