### PR TITLE
Show confirmation dialog before stopping test

### DIFF
--- a/renderer/components/Modal.js
+++ b/renderer/components/Modal.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Fixed, Box } from 'ooni-components'
+import styled from 'styled-components'
+
+export const Modal = styled(Fixed)`
+  z-index: 1001;
+  max-width: 100vw;
+  max-height: 100vh;
+  overflow: auto;
+  transform: translate(-50%, -50%);
+  box-shadow: rgba(0, 0, 0, 0.80) 0 0 0 60vmax, rgba(0, 0, 0, 0.25) 0 0 32px;
+  border-radius: 10px;
+  top: 50%;
+  left: 50%;
+  background-color: ${props => props.bg || props.theme.colors.blue5};
+  visibility: ${props => props.show ? 'visible': 'hidden'};
+`
+
+export const ModalButton = styled(Box)`
+  height: 50px;
+  text-align: center;
+  line-height: 50px;
+  cursor: pointer;
+`
+
+export const YesButton = styled(ModalButton)`
+  background-color: ${props => props.theme.colors.green7};
+  &:hover {
+    background-color: ${props => props.theme.colors.green6};
+  }
+`
+
+export const NoButton = styled(ModalButton)`
+  background-color: ${props => props.theme.colors.red8};
+  &:hover {
+    background-color: ${props => props.theme.colors.red7};
+  }
+`

--- a/renderer/components/home/StopTestModal.js
+++ b/renderer/components/home/StopTestModal.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Flex, Box, Container, Text, Heading } from 'ooni-components'
+import { FormattedMessage } from 'react-intl'
+
+import { Modal, YesButton, NoButton } from '../Modal'
+
+const StopTestModal = ({ show = true, onConfirm = () => {} , onCancel = () => {} }) => {
+  return (
+    <Modal show={show}>
+      <Container p={3}>
+        <Flex flexDirection='column'>
+          <Text textAlign='center'>
+            <Heading h={5}>
+              <FormattedMessage id='Modal.InterruptTest.Title' />
+            </Heading>
+          </Text>
+          <Box my={2}>
+            <Text>
+              <FormattedMessage id='Modal.InterruptTest.Paragraph' />
+            </Text>
+          </Box>
+        </Flex>
+      </Container>
+      <Flex>
+        <YesButton width={1/2} onClick={onConfirm}>
+          <FormattedMessage id='Modal.OK' />
+        </YesButton>
+        <NoButton width={1/2} onClick={onCancel}>
+          <FormattedMessage id='Modal.Cancel' />
+        </NoButton>
+      </Flex>
+    </Modal>
+  )
+}
+
+StopTestModal.propTypes = {
+  show: PropTypes.bool,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func
+}
+
+export default StopTestModal

--- a/renderer/components/home/StopTestModal.js
+++ b/renderer/components/home/StopTestModal.js
@@ -1,36 +1,40 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Flex, Box, Container, Text, Heading } from 'ooni-components'
+import { Flex, Box, Container, Text, Heading, Button, Modal } from 'ooni-components'
 import { FormattedMessage } from 'react-intl'
+import styled from 'styled-components'
 
-import { Modal, YesButton, NoButton } from '../Modal'
+const StyledModal = styled(Modal)`
+  border-radius: 8px;
+  box-shadow: 4px 4px 10px black;
+`
 
 const StopTestModal = ({ show = true, onConfirm = () => {} , onCancel = () => {} }) => {
   return (
-    <Modal show={show}>
+    <StyledModal bg='white' show={show} color='black' closeButton='right' onHideClick={onCancel}>
       <Container p={3}>
         <Flex flexDirection='column'>
           <Text textAlign='center'>
-            <Heading h={5}>
+            <Heading h={4}>
               <FormattedMessage id='Modal.InterruptTest.Title' />
             </Heading>
           </Text>
-          <Box my={2}>
+          <Box my={2} px={5}>
             <Text>
               <FormattedMessage id='Modal.InterruptTest.Paragraph' />
             </Text>
           </Box>
         </Flex>
       </Container>
-      <Flex>
-        <YesButton width={1/2} onClick={onConfirm}>
-          <FormattedMessage id='Modal.OK' />
-        </YesButton>
-        <NoButton width={1/2} onClick={onCancel}>
-          <FormattedMessage id='Modal.Cancel' />
-        </NoButton>
+      <Flex justifyContent='flex-end' my={3}>
+        <Button mx={3} width={1/3} inverted onClick={onCancel}>
+          <Text fontWeight='bold'><FormattedMessage id='Modal.Cancel' /></Text>
+        </Button>
+        <Button mx={3} width={1/3} onClick={onConfirm}>
+          <Text fontWeight='bold'><FormattedMessage id='Modal.OK' /></Text>
+        </Button>
       </Flex>
-    </Modal>
+    </StyledModal>
   )
 }
 

--- a/renderer/components/home/StopTestModal.js
+++ b/renderer/components/home/StopTestModal.js
@@ -3,15 +3,32 @@ import PropTypes from 'prop-types'
 import { Flex, Box, Container, Text, Heading, Button, Modal } from 'ooni-components'
 import { FormattedMessage } from 'react-intl'
 import styled from 'styled-components'
+import { MdClose } from 'react-icons/md'
 
 const StyledModal = styled(Modal)`
   border-radius: 8px;
   box-shadow: 4px 4px 10px black;
 `
 
+const StyledCloseButton = styled(Box)`
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  height: 28px;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: ${props => props.theme.colors.gray7};
+
+  &:hover {
+    color: ${props => props.theme.colors.black};
+  }
+`
+
 const StopTestModal = ({ show = true, onConfirm = () => {} , onCancel = () => {} }) => {
   return (
-    <StyledModal bg='white' show={show} color='black' closeButton='right' onHideClick={onCancel}>
+    <StyledModal bg='white' show={show} color='black' onHideClick={onCancel}>
+      <StyledCloseButton onClick={onCancel}><MdClose size={24} /></StyledCloseButton>
       <Container p={3}>
         <Flex flexDirection='column'>
           <Text textAlign='center'>

--- a/renderer/components/home/running.js
+++ b/renderer/components/home/running.js
@@ -1,5 +1,5 @@
 /* global require */
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import {
   Flex,
@@ -17,6 +17,7 @@ import moment from 'moment'
 
 import { testGroups } from '../nettests'
 import { StripedProgress } from './StripedProgress'
+import StopTestModal from './StopTestModal'
 
 const StyledRunningTest = styled.div`
   text-align: center;
@@ -134,13 +135,25 @@ const RunningTest = ({
   // Use the locale used by react-intl to localize the ETA label ('un minuto')
   const { locale } = useIntl()
 
+  const [showModal, setModalState] = useState(false)
+
   return <StyledRunningTest>
     <Container>
-      {stopping || (
+      {(stopping || showModal) || (
         <CloseButtonContainer>
-          <MdClear onClick={onKill} size={30} />
+          <MdClear onClick={() => setModalState(true)} size={30} />
         </CloseButtonContainer>
       )}
+
+      <StopTestModal
+        show={showModal}
+        onConfirm={() => {
+          onKill()
+          setModalState(false)
+        }}
+        onCancel={() => setModalState(false)}
+      />
+
       <Heading h={2}>{testGroup.name}</Heading>
       <Heading h={3}>
         {stopping ? (

--- a/renderer/components/home/running.js
+++ b/renderer/components/home/running.js
@@ -155,23 +155,20 @@ const RunningTest = ({
       />
 
       <Heading h={2}>{testGroup.name}</Heading>
-      <Heading h={3}>
-        {stopping ? (
-          <FormattedMessage
-            id='Dashboard.Running.Stopping.Title'
-            values={{
-              TestName
-            }}
-          />
-        ):(
-          <FormattedMessage
-            id='Dashboard.Running.Running'
-            values={{
-              TestName
-            }}
-          />
-        )}
-      </Heading>
+      {stopping ? (
+        <Heading h={3}>
+          <FormattedMessage id='Dashboard.Running.Stopping.Title' />
+        </Heading>
+      ):(
+        <Flex flexDirection='column'>
+          <Heading h={3}>
+            <FormattedMessage id='Dashboard.Running.Running' />
+          </Heading>
+          <Text fontSize={4}>
+            {TestName}
+          </Text>
+        </Flex>
+      )}
       {!logOpen && lottieOptions.animationData && (
         <Lottie
           width={300}

--- a/renderer/components/home/running.js
+++ b/renderer/components/home/running.js
@@ -1,5 +1,6 @@
 /* global require */
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {
   Flex,
@@ -238,44 +239,24 @@ const ContentContainer = styled.div`
   z-index: 10;
 `
 
-class Running extends React.Component {
-  constructor(props) {
-    super(props)
+const Running = ({
+  testGroupName,
+  progressLine,
+  percent,
+  runningTestName,
+  logLines,
+  eta,
+  error,
+  onKill,
+  stopping
+}) => {
 
-    this.state = {
-      error: null,
-      logOpen: false,
-      done: true
-    }
-    this.onToggleLog = this.onToggleLog.bind(this)
-  }
+  const [logOpen, setLogOpen] = useState(false)
 
-  onToggleLog() {
-    this.setState({
-      logOpen: !this.state.logOpen
-    })
-  }
+  const testGroup = testGroups[testGroupName]
 
-  render() {
-    const {
-      testGroupName,
-      progressLine,
-      percent,
-      runningTestName,
-      logLines,
-      eta,
-      error,
-      onKill,
-      stopping
-    } = this.props
-
-    const {
-      logOpen
-    } = this.state
-
-    const testGroup = testGroups[testGroupName]
-
-    return <WindowContainer bg={testGroup.color}>
+  return (
+    <WindowContainer bg={testGroup.color}>
       <WindowDraggable bg={testGroup.color} />
       <ContentContainer color={testGroup.color}>
         <RunningTest
@@ -288,12 +269,12 @@ class Running extends React.Component {
           logOpen={logOpen}
           onKill={onKill}
           stopping={stopping}
-          onToggleLog={this.onToggleLog}
+          onToggleLog={() => setLogOpen(!logOpen)}
           eta={eta}
         />
       </ContentContainer>
     </WindowContainer>
-  }
+  )
 }
 
 Running.defaultProps = {
@@ -304,4 +285,17 @@ Running.defaultProps = {
   error: null,
   runningTestName: ''
 }
+
+Running.propTypes = {
+  testGroupName: PropTypes.string,
+  progressLine: PropTypes.string,
+  percent: PropTypes.number,
+  runningTestName: PropTypes.string,
+  logLines: PropTypes.array,
+  eta: PropTypes.number,
+  error: PropTypes.string,
+  onKill: PropTypes.func,
+  stopping: PropTypes.bool
+}
+
 export default Running

--- a/renderer/components/onboard/QuizSteps.js
+++ b/renderer/components/onboard/QuizSteps.js
@@ -12,20 +12,10 @@ import {
   Divider,
   theme
 } from 'ooni-components'
+
+import { Modal, YesButton, NoButton } from '../Modal'
 import { default as tickAnimation } from '../../static/animations/checkMark.json'
 import { default as crossAnimation } from '../../static/animations/crossMark.json'
-
-const QuizModal = styled(Fixed)`
-  max-width: 100vw;
-  max-height: 100vh;
-  overflow: auto;
-  transform: translate(-50%, -50%);
-  box-shadow: rgba(0, 0, 0, 0.80) 0 0 0 60vmax, rgba(0, 0, 0, 0.25) 0 0 32px;
-  border-radius: 10px;
-  top: 50%;
-  left: 50%;
-  background-color: ${props => props.bg || props.theme.colors.blue5};
-`
 
 const QuizButton = styled(Box)`
   height: 50px;
@@ -46,21 +36,6 @@ const ContinueButton = styled(QuizButton)`
   background-color: ${props => props.theme.colors.gray4};
   &:hover {
     background-color: ${props => props.theme.colors.gray3};
-  }
-`
-
-
-const TrueButton = styled(QuizButton)`
-  background-color: ${props => props.theme.colors.green7};
-  &:hover {
-    background-color: ${props => props.theme.colors.green6};
-  }
-`
-
-const FalseButton = styled(QuizButton)`
-  background-color: ${props => props.theme.colors.red8};
-  &:hover {
-    background-color: ${props => props.theme.colors.red7};
   }
 `
 
@@ -100,12 +75,12 @@ const QuizQuestion = ({qNum, question, onTrue, onFalse}) => (
       </Heading>
       <Text mx={3} my={4} textAlign='center'>{question}</Text>
       <Flex>
-        <TrueButton width={1/2} onClick={onTrue}>
+        <YesButton width={1/2} onClick={onTrue}>
           <FormattedMessage id='Onboarding.PopQuiz.True' />
-        </TrueButton>
-        <FalseButton width={1/2} onClick={onFalse}>
+        </YesButton>
+        <NoButton width={1/2} onClick={onFalse}>
           <FormattedMessage id='Onboarding.PopQuiz.False' />
-        </FalseButton>
+        </NoButton>
       </Flex>
     </div>
   </Box>
@@ -232,7 +207,7 @@ class QuizSteps extends React.Component {
     }
 
     return (
-      <QuizModal bg={modalBg}>
+      <Modal show={true} bg={modalBg}>
         <Fixed top right bottom left />
         {(showOkayAnimation || showNopeAnimation) ? (
           showAnimation()
@@ -253,7 +228,7 @@ class QuizSteps extends React.Component {
             />
           )
         )}
-      </QuizModal>
+      </Modal>
     )
   }
 }

--- a/renderer/pages/home.js
+++ b/renderer/pages/home.js
@@ -14,8 +14,6 @@ import Running from '../components/home/running'
 import { testList } from '../components/nettests'
 import StickyDraggableHeader from '../components/StickyDraggableHeader'
 
-import StopTestModal from '../components/home/StopTestModal'
-
 const debug = require('debug')('ooniprobe-desktop.renderer.pages.dashboard')
 
 const CardContent = styled.div`

--- a/renderer/pages/home.js
+++ b/renderer/pages/home.js
@@ -14,6 +14,8 @@ import Running from '../components/home/running'
 import { testList } from '../components/nettests'
 import StickyDraggableHeader from '../components/StickyDraggableHeader'
 
+import StopTestModal from '../components/home/StopTestModal'
+
 const debug = require('debug')('ooniprobe-desktop.renderer.pages.dashboard')
 
 const CardContent = styled.div`


### PR DESCRIPTION
Fixes ooni/probe#1205
![Screenshot from 2020-06-26 01-19-14](https://user-images.githubusercontent.com/700829/85823325-1fabbb80-b74b-11ea-8ec5-925ae2c35e26.png)

I used the same style we use in the onboarding screens. I tried using the buttons from our design system, but dropped it later.
![Screenshot from 2020-06-26 00-47-24](https://user-images.githubusercontent.com/700829/85823385-4d910000-b74b-11ea-8ed2-8f5a8ca881a4.png)


Also fixes the bug where the currently running test name wasn't being shown.
![Screenshot from 2020-06-26 01-19-08](https://user-images.githubusercontent.com/700829/85823331-29352380-b74b-11ea-870c-edd4ff00f221.png)

