### PR TITLE
Disable animation pause on click during onboarding

### DIFF
--- a/renderer/components/onboard/QuizSteps.js
+++ b/renderer/components/onboard/QuizSteps.js
@@ -124,6 +124,7 @@ const Animation = ({ okay, onComplete }) => {
     <Lottie
       width={400}
       height={270}
+      isClickToPauseDisabled={true}
       options={{
         loop: false,
         autoplay: true,


### PR DESCRIPTION
Fixes ooni/probe#1196

By default `<Lottie>`﻿ allows click to pause the animation. This PR changes
the default behaviour to disable the pause on click.

