### PR TITLE
Release 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## OONI Probe Desktop 3.0.3 [2020-06-29]
+
+probe-cli: 3.0.3
+
+### Fixes
+* Fix missing auto update notice in about window (ooni/probe#1184)
+* Fix logic in looking for informed consent in config file (ooni/probe#1188)
+* Fix long paths in about window debug section (ooni/probe#1116)
+* Fix missing translation string in when stopping a test (ooni/probe#1204)
+* Disable pausing of animation during onboarding quiz (ooni/probe#1196)
+
+### Changes
+* Removed styling of bootstrap time unit in Psiphon measurement details
+
+### Security
+* Bump websocket-extensions from 0.1.3 to 0.1.4 [dependabot]
+
+### Dependencies
+* Bumped `electron-builder` to `22.7.0`
+* Bumped `electron-updater` to `4.3.1`
+
 ## OONI Probe Desktop 3.0.2 [2020-06-03]
 
 probe-cli: 3.0.1
@@ -11,6 +32,10 @@ probe-cli: 3.0.1
 ### Changed
 
 * Show measurements in local system timezone
+
+### Removed
+
+* Dropped macos from e2e testing matrix because it times out too often
 
 ## OONI Probe Desktop 3.0.1 [2020-05-05]
 

--- a/main/index.js
+++ b/main/index.js
@@ -139,7 +139,7 @@ autoUpdater.on('checking-for-update', () => {
 })
 
 autoUpdater.on('update-available', () => {
-  sendStatusToWindow('Update available.', { showWindow: true })
+  sendStatusToWindow('A new update is available. Downloading now...', { showWindow: true })
 })
 
 autoUpdater.on('error', err => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OONI Probe Desktop app",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
-  "version": "3.0.3-dev",
+  "version": "3.0.3",
   "probeVersion": "3.0.3",
   "main": "main/index.js",
   "license": "MIT",

--- a/renderer/components/home/running.js
+++ b/renderer/components/home/running.js
@@ -142,23 +142,20 @@ const RunningTest = ({
         </CloseButtonContainer>
       )}
       <Heading h={2}>{testGroup.name}</Heading>
-      <Heading h={3}>
-        {stopping ? (
-          <FormattedMessage
-            id='Dashboard.Running.Stopping.Title'
-            values={{
-              TestName
-            }}
-          />
-        ):(
-          <FormattedMessage
-            id='Dashboard.Running.Running'
-            values={{
-              TestName
-            }}
-          />
-        )}
-      </Heading>
+      {stopping ? (
+        <Heading h={3}>
+          <FormattedMessage id='Dashboard.Running.Stopping.Title' />
+        </Heading>
+      ):(
+        <Flex flexDirection='column'>
+          <Heading h={3}>
+            <FormattedMessage id='Dashboard.Running.Running' />
+          </Heading>
+          <Text fontSize={4}>
+            {TestName}
+          </Text>
+        </Flex>
+      )}
       {!logOpen && lottieOptions.animationData && (
         <Lottie
           width={300}


### PR DESCRIPTION
## OONI Probe Desktop 3.0.3 [2020-06-29]

probe-cli: 3.0.3

### Fixes
* Fix missing auto update notice in about window (ooni/probe#1184)
* Fix logic in looking for informed consent in config file (ooni/probe#1188)
* Fix long paths in about window debug section (ooni/probe#1116)
* Fix missing translation string in when stopping a test (ooni/probe#1204)
* Disable pausing of animation during onboarding quiz (ooni/probe#1196)

### Changes
* Removed styling of bootstrap time unit in Psiphon measurement details

### Security
* Bump websocket-extensions from 0.1.3 to 0.1.4 [dependabot]

### Dependencies
* Bumped `electron-builder` to `22.7.0`
* Bumped `electron-updater` to `4.3.1`
﻿
