### PR TITLE
Fix spacing and alignment of result overview contents

### DIFF
--- a/renderer/components/HumanFilesize.js
+++ b/renderer/components/HumanFilesize.js
@@ -4,9 +4,7 @@ import styled from 'styled-components'
 
 import humanize from 'humanize'
 
-import {
-  Flex
-} from 'ooni-components'
+import { Flex, Box } from 'ooni-components'
 
 const FileUnit = styled.span`
   font-size: ${props => props.fontSize/2}px;
@@ -17,14 +15,16 @@ const FileAmount = styled.span`
   font-weight: 300;
 `
 
-const HumanFilesize = ({icon, size, fontSize}) => {
+const HumanFilesize = ({icon, size, fontSize, ...rest}) => {
   const human = humanize.filesize(size)
   const [amount, unit] = human.split(' ')
   return (
-    <Flex alignItems='baseline'>
+    <Flex alignItems='center' {...rest}>
       {icon}
-      <FileAmount fontSize={fontSize}>{amount}</FileAmount>
-      <FileUnit fontSize={fontSize}>{unit}</FileUnit>
+      <Box>
+        <FileAmount fontSize={fontSize}>{amount}</FileAmount>
+        <FileUnit fontSize={fontSize}>{unit}</FileUnit>
+      </Box>
     </Flex>
   )
 }

--- a/renderer/components/TwoColumnTable.js
+++ b/renderer/components/TwoColumnTable.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import {
   Flex,
@@ -7,7 +8,7 @@ import {
 
 const TwoColumnTable = ({left, right}) => {
   return (
-    <Flex alignItems='center' mb={1}>
+    <Flex alignItems='center' mb={2}>
       <Box>
         {left}
       </Box>
@@ -16,6 +17,11 @@ const TwoColumnTable = ({left, right}) => {
       </Box>
     </Flex>
   )
+}
+
+TwoColumnTable.propTypes = {
+  left: PropTypes.node,
+  right: PropTypes.node
 }
 
 export default TwoColumnTable

--- a/renderer/components/result/ResultContainer.js
+++ b/renderer/components/result/ResultContainer.js
@@ -42,8 +42,8 @@ const ResultOverviewContainer = styled.div`
 
 const OverviewLabel = ({ icon, label }) => (
   <Flex flexDirection='row' alignItems='center'>
-    <Box mr={1}>{icon}</Box>
-    <Box>{label}</Box>
+    {icon}
+    <Box ml={2}>{label}</Box>
   </Flex>
 )
 
@@ -134,7 +134,7 @@ const ResultOverview = ({
           }
           right={
             <Flex>
-              <HumanFilesize icon={<MdArrowUpward size={20}/>} size={dataUsageUp*1024} fontSize={20} />
+              <HumanFilesize mx={2} icon={<MdArrowUpward size={20}/>} size={dataUsageUp*1024} fontSize={20} />
               <HumanFilesize icon={<MdArrowDownward size={20}/>} size={dataUsageDown*1024} fontSize={20} />
             </Flex>}
         />


### PR DESCRIPTION
Fixes ooni/probe#1043
spacing between icons and labels.
![image](https://user-images.githubusercontent.com/700829/92523850-0fa26480-f1ef-11ea-8f30-bd464353f31d.png)

Also went ahead and increased the vertical spacing between the rows. The screen looks like this. 

![image](https://user-images.githubusercontent.com/700829/92523810-fc8f9480-f1ee-11ea-88db-a1d5bbd05b77.png)
