### PR TITLE
Release 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
+## OONI Probe Desktop 3.0.4 [2020-10-14]
+
+probe-cli: 3.0.8
+
+### Fixes
+* Flickering when running a test (ooni/probe#1189)
+* Fix crash when viewing results of stopped tests (ooni/probe#1245)
+* Fix alignment of buttons in onboarding screens (ooni/probe#1138)
+* Fix spacing and alignment of result overview section (ooni/probe#1043)
+
+### Changes
+* Skip downloading `zip` archive of probe-cli in the download script (#176)
+
+### Security
+* Dependabot version bumps for `electron`, `elliptic`, `lodash`, `markdown-to-jsx`
+
+### Dependencies
+* Replace `react-lottie` with `react-lottie-player`
 
 ## OONI Probe Desktop 3.0.3 [2020-06-29]
 

--- a/Readme.md
+++ b/Readme.md
@@ -59,12 +59,14 @@ time point, dispose of the the `.p12` file using `rm -P`.
 Create a `.env` file in the root directory with the following content:
 
 ```bash
+GH_TOKEN=TOKEN
 OONI_APPLEID=your@apple.id
 OONI_APPLEIDPASS=XXXX
 OONI_TEAMID=YWCG8FZTLT
 ```
 
-where `your@apple.id` is the Apple ID you are using as part of our
+where `TOKEN` is a [personal github token](https://github.com/settings/tokens/new)
+with repository scope, `your@apple.id` is the Apple ID you are using as part of our
 team, `XXXX` is a password specific application created by visiting
 https://appleid.apple.com and logging in as `your@apple.id`, and
 `YWCG8FZTLT` is the team ID used by OONI.
@@ -91,7 +93,8 @@ Run:
 
 ```bash
 yarn install
-yarn run publish
+yarn run publish:mac
+yarn run publish:win
 ```
 
 **Important caveat** be sure to not push the tag for the upcoming release until

--- a/Readme.md
+++ b/Readme.md
@@ -27,40 +27,70 @@ You will also need to have copied a compiled binary of `probe-cli` into the
 directory for the platform you plan to do development on.
 
 You can download them by running:
-```
+
+```bash
 yarn run probe-cli
 ```
 
-## Usage
+## Run app in development mode
 
 To build and run a development mode electron instance run:
-```
+
+```bash
 yarn run start
 ```
 
-To update the translations:
+## Update the translations
+
 * Save the strings from the canonical spreadsheet into `data/lang-en.csv`
 * Run `$ node scripts/update-translations.js`
 * Commit `data/lang-en.csv`, `lang/en.json` and `renderer/static/translations.js`
 into git
 
-To create a signed packaged app you will need to have configured the following
-environment variables:
+## Build and sign macOS app
 
+Obtain the development certificate and private key for our team (`YWCG8FZTLT`)
+from another OONI developer who has access to it. They need to ensure they export
+not only the certificate but also the related private key. You should receive a
+password encrypted `.p12` file containing both. Just double click on this file and
+provide the password to import the certificate and the key into your keyring. At
+time point, dispose of the the `.p12` file using `rm -P`.
+
+Create a `.env` file in the root directory with the following content:
+
+```bash
+OONI_APPLEID=your@apple.id
+OONI_APPLEIDPASS=XXXX
+OONI_TEAMID=YWCG8FZTLT
 ```
-CSC_NAME=Hermes OONI Dev Key
-APPLEIDPASS=XXXX
-APPLEID=xxx@yyy.com
 
-CSC_LINK=/path/to/secrets/file.p12
-CSC_KEY_PASSWORD=XXXX
+where `your@apple.id` is the Apple ID you are using as part of our
+team, `XXXX` is a password specific application created by visiting
+https://appleid.apple.com and logging in as `your@apple.id`, and
+`YWCG8FZTLT` is the team ID used by OONI.
+
+Then, run:
+
+```bash
+yarn install
+yarn pack:mac
 ```
 
-You can place them inside of `.env` file and they will be picked up by the
-following build commands.
+This will build `./dist/OONI Probe-$VERSION.dmg`.
 
-To publish a release you should run:
+## Build and sign an app on Windows
+
+```bash
+yarn install
+yarn run pack:win
 ```
+
+## Publish a release
+
+Run:
+
+```bash
+yarn install
 yarn run publish
 ```
 
@@ -68,10 +98,3 @@ yarn run publish
 after the `yarn run publish` command has run successfully. If you do so users
 of the OONI Probe Desktop app will get an error when they start the app because
 the auto-update system will try to fetch the metadata associated with that tag.
-
-You can also make a build, but not publish it by running the following commands:
-```
-yarn run pack:mac
-yarn run pack:win
-yarn run pack:linux
-```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OONI Probe Desktop app",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
-  "version": "3.0.4-rc.3",
+  "version": "3.0.4",
   "probeVersion": "3.0.8",
   "main": "main/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OONI Probe Desktop app",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
-  "version": "3.0.4-rc.1",
+  "version": "3.0.4-rc.2",
   "probeVersion": "3.0.8",
   "main": "main/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OONI Probe Desktop app",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
-  "version": "3.0.4-rc.2",
+  "version": "3.0.4-rc.3",
   "probeVersion": "3.0.8",
   "main": "main/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OONI Probe Desktop app",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
-  "version": "3.0.4-dev",
+  "version": "3.0.4-rc.1",
   "probeVersion": "3.0.8",
   "main": "main/index.js",
   "license": "MIT",

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -18,7 +18,8 @@ exports.default = async function notarizing(context) {
   return await notarize({
     appBundleId: appBundleId,
     appPath: `${appOutDir}/${appName}.app`,
-    appleId: process.env.APPLEID,
-    appleIdPassword: process.env.APPLEIDPASS,
+    appleId: process.env.OONI_APPLEID,
+    appleIdPassword: process.env.OONI_APPLEIDPASS,
+    ascProvider: process.env.OONI_TEAMID,
   })
 }


### PR DESCRIPTION
Updated version to `3.0.4-rc.1` to test before release. We will bump it to `3.0.4` after we some internal testing and then tag it for the release build to publish.

Tracking issue: https://github.com/ooni/ooni.org/issues/600