### PR TITLE
Change default values at end of onboarding process

### DIFF
--- a/main/ipcBindings.js
+++ b/main/ipcBindings.js
@@ -2,6 +2,7 @@ const { app } = require('electron')
 const fs = require('fs-extra')
 const { listResults } = require('./actions')
 const { Runner } = require('./utils/ooni/run')
+const onboard = require('./utils/ooni/onboard')
 
 // BUG: The idea *was* to use these constants across main and renderer processes
 // to wire up the IPC channels. But importing these directly from renderer
@@ -79,6 +80,7 @@ const ipcBindingsForMain = (ipcMain) => {
       }
     }
     sender.send('ooniprobe.completed')
+    testRunner = null
   })
 
   ipcMain.on('ooniprobe.stop', async (event) => {
@@ -90,6 +92,10 @@ const ipcBindingsForMain = (ipcMain) => {
       testRunner.kill()
       stopRequested = true
     }
+  })
+
+  ipcMain.handle('config.onboard', async (event, { optout = false }) => {
+    await onboard({ optout })
   })
 }
 

--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -43,7 +43,12 @@ const availableCategoriesList = [
   'XED'
 ]
 
-const initConfigFile = async () => {
+const defaultOptions = {
+  optout: false
+}
+
+const initConfigFile = async (options) => {
+  const opts = Object.assign(defaultOptions, options)
   const config = {
     '_version': LATEST_CONFIG_VERSION,
     '_informed_consent': true,
@@ -59,8 +64,8 @@ const initConfigFile = async () => {
     },
     'advanced': {
       'use_domain_fronting': false,
-      'send_crash_reports': true,
-      'collect_usage_stats': true,
+      'send_crash_reports': !opts.optout,
+      'collect_usage_stats': !opts.optout,
       'collector_url': '',
       'bouncer_url': 'https://bouncer.ooni.io'
     }

--- a/main/utils/ooni/onboard.js
+++ b/main/utils/ooni/onboard.js
@@ -1,6 +1,6 @@
 /* global module, require */
 const { initConfigFile } = require('../config')
 
-module.exports = () => {
-  return initConfigFile()
+module.exports = (opts) => {
+  return initConfigFile(opts)
 }

--- a/renderer/pages/onboard.js
+++ b/renderer/pages/onboard.js
@@ -2,7 +2,7 @@
 import React, { useCallback } from 'react'
 
 import Router from 'next/router'
-
+import { ipcRenderer } from 'electron'
 import styled from 'styled-components'
 
 import Layout from '../components/Layout'
@@ -14,21 +14,14 @@ const SectionContainer = styled.div`
 
 const Onboard = () => {
 
-  const OnboardingComplete = useCallback(() => {
-    const { remote } = require('electron')
-    return remote.require('./utils/ooni/onboard')()
+  const onGo = useCallback(async () => {
+    await ipcRenderer.invoke('config.onboard', {})
+    Router.push('/dashboard')
   }, [])
 
-  const onGo = useCallback(() => {
-    OnboardingComplete().then(() => {
-      Router.push('/dashboard')
-    })
-  }, [])
-
-  const onChange = useCallback(() => {
-    OnboardingComplete().then(() => {
-      Router.push('/settings')
-    })
+  const onChange = useCallback(async () => {
+    await ipcRenderer.invoke('config.onboard', { optout: true })
+    Router.push('/settings')
   }, [])
 
   return (

--- a/renderer/pages/settings.js
+++ b/renderer/pages/settings.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useState, useCallback } from 'react'
-import electron from 'electron'
+import PropTypes from 'prop-types'
+import React, { useMemo } from 'react'
 import { FormattedMessage } from 'react-intl'
 import styled from 'styled-components'
 import {
@@ -38,9 +38,17 @@ const Section = ({ title, children }) => (
   </Flex>
 )
 
+Section.propTypes = {
+  children: PropTypes.node,
+  title: PropTypes.string
+}
+
 const Settings = () => {
   const [config, /*setConfig, loading, err*/] = useConfig()
-  const maxRuntimeEnabled = config['nettests']['websites_enable_max_runtime']
+  const maxRuntimeEnabled = useMemo(() => {
+    return config ? config.nettests.websites_enable_max_runtime : undefined
+  }, [config])
+
   return (
     <Layout>
       <Sidebar>
@@ -77,6 +85,10 @@ const Settings = () => {
               <BooleanOption
                 label={<FormattedMessage id='Settings.Privacy.CollectAnalytics' />}
                 optionKey='advanced.collect_usage_stats'
+              />
+              <BooleanOption
+                label={<FormattedMessage id='Settings.Privacy.SendCrashReports' />}
+                optionKey='advanced.send_crash_reports'
               />
               <BooleanOption
                 label={<FormattedMessage id='Settings.Sharing.UploadResults' />}

--- a/renderer/pages/settings.js
+++ b/renderer/pages/settings.js
@@ -83,6 +83,10 @@ const Settings = () => {
             {/* Privacy */}
             <Section title={<FormattedMessage id='Settings.Privacy.Label' />}>
               <BooleanOption
+                label={<FormattedMessage id='Settings.Sharing.UploadResults' />}
+                optionKey='sharing.upload_results'
+              />
+              <BooleanOption
                 label={<FormattedMessage id='Settings.Privacy.CollectAnalytics' />}
                 optionKey='advanced.collect_usage_stats'
               />
@@ -91,16 +95,8 @@ const Settings = () => {
                 optionKey='advanced.send_crash_reports'
               />
               <BooleanOption
-                label={<FormattedMessage id='Settings.Sharing.UploadResults' />}
-                optionKey='sharing.upload_results'
-              />
-              <BooleanOption
                 label={<FormattedMessage id='Settings.Sharing.IncludeNetwork' />}
                 optionKey='sharing.include_asn'
-              />
-              <BooleanOption
-                label={<FormattedMessage id='Settings.Sharing.IncludeIP' />}
-                optionKey='sharing.include_ip'
               />
             </Section>
 


### PR DESCRIPTION
At end of onboarding when 'Change defaults' is clicked, we set the config to opt-out of analytics. Problem with letting the user perform the change action is that a config file is already written by then and it would have 'opted-in' to allow the user to opt-out and then stands the risk of staying opted-in if the app is closed or navigated away. We should discuss if this is how we want to do this.