### PR TITLE
chore: use ooni/probe-cli 3.9.0

### DIFF
--- a/main/utils/ooni/ooniprobe.js
+++ b/main/utils/ooni/ooniprobe.js
@@ -100,11 +100,11 @@ class Ooniprobe extends EventEmitter {
         reject(err)
       })
 
-      self.ooni.stdout.on('data', data => {
+      self.ooni.stderr.on('data', data => {
         log.error('stderr: ', data.toString())
       })
 
-      self.ooni.stderr.pipe(split2()).on('data', line => {
+      self.ooni.stdout.pipe(split2()).on('data', line => {
         log.verbose('stdout: ', line.toString())
         try {
           const msg = JSON.parse(line.toString('utf8'))

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.4.0-dev",
-  "probeVersion": "3.8.0",
+  "probeVersion": "3.9.0",
   "main": "main/index.js",
   "license": "BSD-3-Clause",
   "repository": "ooni/probe-desktop",


### PR DESCRIPTION
Fixes ooni/probe#1425
* Revert the swapping of stdout and stderr when talking to probe-cli
* This build also runs Signal tests and shows the results and measurements properly.

![image](https://user-images.githubusercontent.com/700829/113620247-13348780-9628-11eb-88f1-c672645d99f1.png)

Release notes for probe-cli@3.9.0](https://github.com/ooni/probe-cli/releases/tag/v3.9.0)