### PR TITLE
[Fix] Input URL fields need not be dirty for validation

### DIFF
--- a/renderer/components/dashboard/URL.js
+++ b/renderer/components/dashboard/URL.js
@@ -45,36 +45,6 @@ const RemoveButton = styled(Button)`
 
 const URL = ({ idx, url, error, onUpdate, onRemove, onKeyEnter }) => {
   const [dirty, setDirty] = useState(false)
-  const onChange = useCallback((e) => {
-    onUpdate(idx, e.target.value)
-
-    // Also start validting one the field is dirty
-    // this lets UrlList to make the Run button active as soon as an error is fixed
-    function alsoValidate() {
-      const { hasError, error } = validateURL(e.target.value)
-      onUpdate(idx, e.target.value, hasError, error)
-    }
-
-    dirty && alsoValidate()
-  }, [idx, dirty, onUpdate, validateURL])
-
-  const onDelete = useCallback(() => {
-    onRemove(idx)
-  }, [idx, onRemove])
-
-  const onKeyPress = useCallback((e) => {
-    if (e.key === 'Enter') {
-      onKeyEnter(idx)
-    }
-  }, [idx, onKeyEnter])
-
-  const onBlur = useCallback((e) => {
-    if (!dirty) {
-      setDirty(true)
-    }
-    const { hasError, error } = validateURL(e.target.value)
-    onUpdate(idx, e.target.value, hasError, error)
-  }, [idx, dirty, validateURL, onUpdate])
 
   const validateURL = useCallback((input) => {
     let hasError = false
@@ -100,6 +70,37 @@ const URL = ({ idx, url, error, onUpdate, onRemove, onKeyEnter }) => {
     }
   }, [])
 
+  const onChange = useCallback((e) => {
+    onUpdate(idx, e.target.value)
+
+    // Also start validting one the field is dirty
+    // this lets UrlList to make the Run button active as soon as an error is fixed
+    function alsoValidate() {
+      const { hasError, error } = validateURL(e.target.value)
+      onUpdate(idx, e.target.value, hasError, error)
+    }
+
+    alsoValidate()
+  }, [idx, onUpdate, validateURL])
+
+  const onDelete = useCallback(() => {
+    onRemove(idx)
+  }, [idx, onRemove])
+
+  const onKeyPress = useCallback((e) => {
+    if (e.key === 'Enter') {
+      onKeyEnter(idx)
+    }
+  }, [idx, onKeyEnter])
+
+  const onBlur = useCallback((e) => {
+    if (!dirty) {
+      setDirty(true)
+    }
+    const { hasError, error } = validateURL(e.target.value)
+    onUpdate(idx, e.target.value, hasError, error)
+  }, [idx, dirty, validateURL, onUpdate])
+
   return (
     <URLBox my={3}>
       <URLInput
@@ -107,17 +108,18 @@ const URL = ({ idx, url, error, onUpdate, onRemove, onKeyEnter }) => {
         name={idx}
         spellCheck={false}
         placeholder='https://'
-        value={url}
+        value={url || ''}
         onChange={onChange}
         onBlur={onBlur}
         onKeyPress={onKeyPress}
         error={error}
+        data-testid='url-input'
       />
       <label htmlFor={idx}>
         <FormattedMessage id='Settings.Websites.CustomURL.URL' />
       </label>
       {onRemove &&
-        <RemoveButton onClick={onDelete}>
+        <RemoveButton onClick={onDelete} data-testid={`urlRemove${idx}`}>
           <MdRemoveCircle size={32} />
         </RemoveButton>
       }


### PR DESCRIPTION
There are a couple of changes proposed in this PR: 
1. `validateURL` function has been shifted up so that it is declared first before a reference to it is made. I was getting error in `jest` that said a reference to the function was made before it was declared.
2. The condition that URL fields need to be dirty before calling the validation function has been removed. Now any change that happens to the textbox is validated.

The reason for this change is because of unexpected behavior arising in presence of this condition.
* The `Run` button would not enable unless focus was shifted to some other element in a headful environment. In a headless environment, the button wouldn't enable at all.
* Validation would not trigger unless focus was shifted to some other element.

The behavior is reproduced here: 
https://user-images.githubusercontent.com/32863230/123514663-b342ff80-d6b1-11eb-994c-e90eea8e6225.mp4

This behavior is fixed by removing the condition

![Screenshot from 2021-06-26 18 50 30](https://user-images.githubusercontent.com/32863230/123514719-f8673180-d6b1-11eb-815d-34aaf6b1db68.png)
![Screenshot from 2021-06-26 18 50 54](https://user-images.githubusercontent.com/32863230/123514721-f8ffc800-d6b1-11eb-9103-bebf4e583760.png)


