### PR TITLE
OS dependency added to some E2E tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint --ignore-path .gitignore .",
     "test:unit": "jest -c test/lib/unit.config.js",
     "test:e2e": "jest -c test/lib/integration.config.js --testRegex 'e2e.js' --runInBand",
+    "test:current": "jest dashboard.e2e.js -c test/lib/integration.config.js --testRegex 'e2e.js'",
     "postinstall": "electron-builder install-app-deps",
     "storybook": "start-storybook -p 6006"
   },
@@ -133,6 +134,7 @@
     "jest-canvas-mock": "^2.3.1",
     "jest-css-modules-transform": "^4.2.1",
     "jest-dom": "^4.0.0",
+    "jest-os-detection": "^1.3.1",
     "jest-styled-components": "^7.0.4",
     "moment-range": "^4.0.2",
     "next": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "lint": "eslint --ignore-path .gitignore .",
     "test:unit": "jest -c test/lib/unit.config.js",
     "test:e2e": "jest -c test/lib/integration.config.js --testRegex 'e2e.js' --runInBand",
-    "test:current": "jest dashboard.e2e.js -c test/lib/integration.config.js --testRegex 'e2e.js'",
     "postinstall": "electron-builder install-app-deps",
     "storybook": "start-storybook -p 6006"
   },

--- a/renderer/components/AutorunConfirmation.js
+++ b/renderer/components/AutorunConfirmation.js
@@ -24,21 +24,21 @@ const AutorunConfirmation = ({ show, onClose }) => {
   return (
     <Modal width='60%' show={show}>
       <StyledCloseButton onClick={onClose}><MdClose size={24} /></StyledCloseButton>
-      <Container>
-        <Heading h={4} my={3} textAlign='center'>
+      <Container data-testid='modal-autorun-confirmation'>
+        <Heading h={4} my={3} textAlign='center' data-testid='heading-autorun-confirmation'>
           <FormattedMessage id='Modal.Autorun.Modal.Title' />
         </Heading>
-        <Flex>
+        <Flex data-testid='text-autorun-confirmation'>
           <FormattedMarkdownMessage id='Modal.Autorun.Modal.Text' />
         </Flex>
         <Flex justifyContent='flex-end' my={3}>
-          <Button ml={2} inverted onClick={onCancel}>
+          <Button ml={2} inverted onClick={onCancel} data-testid='button-autorun-no'>
             <strong><FormattedMessage id='Modal.NoThanks' /></strong>
           </Button>
-          <Button ml={2} inverted onClick={onRemindLater}>
+          <Button ml={2} inverted onClick={onRemindLater} data-testid='button-autorun-remind-later'>
             <strong><FormattedMessage id='Modal.Autorun.Modal.Button.RemindLater' /></strong>
           </Button>
-          <Button ml={2} onClick={onConfirm}>
+          <Button ml={2} onClick={onConfirm} data-testid='button-autorun-yes'>
             <strong><FormattedMessage id='Modal.SoundsGreat' /></strong>
           </Button>
         </Flex>

--- a/renderer/pages/settings.js
+++ b/renderer/pages/settings.js
@@ -85,6 +85,7 @@ const Settings = () => {
               <AutorunCheckbox
                 label={<FormattedMessage id='Settings.AutomatedTesting.RunAutomatically' />}
                 optionKey='autorun.enabled'
+                data-testid='checkbox-autorun'
               />
               <Text as='small'><em><FormattedMarkdownMessage id='Settings.AutomatedTesting.RunAutomatically.Footer' /></em></Text>
             </Section>

--- a/test/dashboard.e2e.js
+++ b/test/dashboard.e2e.js
@@ -1,6 +1,6 @@
-const { startApp, stopApp, screenshotApp } = require('./utils')
+import { startApp, stopApp, screenshotApp } from './utils'
 
-describe('Dashboard tests', () => {
+describe.onLinux('Dashboard tests on Linux', () => {
   let app
 
   beforeAll(async () => {
@@ -15,7 +15,7 @@ describe('Dashboard tests', () => {
     await screenshotApp(app, expect.getState().currentTestName)
   })
 
-  test('Run button is displayed on Dashboard', async () => {
+  test('Run button is displayed on Dashboard on Linux', async () => {
     const runButtonText = await app.client
       .$('button[data-testid=button-dashboard-run]')
       .getText()
@@ -23,7 +23,7 @@ describe('Dashboard tests', () => {
     expect(runButtonText).toMatch('Run')
   })
 
-  describe('All 5 test cards are visible', () => {
+  describe('All 5 test cards are visible on Linux', () => {
     const testDetails = [
       {
         id: 'websites',
@@ -53,7 +53,7 @@ describe('Dashboard tests', () => {
     ]
 
     testDetails.forEach((itr) => {
-      test(`${itr.id} test card is visible`, async () => {
+      test(`${itr.id} test card is visible on Linux`, async () => {
         const isCardVisible = await app.client.isVisible(
           `div[data-testid=run-card-${itr.id}]`
         )
@@ -72,7 +72,7 @@ describe('Dashboard tests', () => {
     })
   })
 
-  test('Clicking on "Test Results" tab loads the Test Results Page', async () => {
+  test('Clicking on "Test Results" tab loads the Test Results Page on Linux', async () => {
     await app.client
       .$('div[data-testid=sidebar-item-test-results]')
       .click()
@@ -97,18 +97,321 @@ describe('Dashboard tests', () => {
     // screenshotApp(app, 'dashboard-test-results')
   })
 
-  test('Clicking on "Settings" tab loads the Settings page', async () => {
+  test('Clicking on "Settings" tab loads the Settings page on Linux', async () => {
     await app.client
       .$('div[data-testid=sidebar-item-settings]')
       .click()
       .pause(500)
-    
+
     await app.client.waitUntilWindowLoaded()
 
     // Checking for the "Settings" heading
     // Rest of the assertions are in settings.e2e.js
     const labelTestOptionsVisible = await app.client.isVisible('h3=Settings')
     expect(labelTestOptionsVisible).toBe(true)
+
+    // screenshotApp(app, 'dashboard-settings-page')
+  })
+})
+
+
+describe.onMac('Dashboard tests on Mac', () => {
+  let app
+
+  beforeAll(async () => {
+    app = await startApp()
+  })
+
+  afterAll(async () => {
+    await stopApp(app)
+  })
+
+  afterEach(async () => {
+    await screenshotApp(app, expect.getState().currentTestName)
+  })
+
+  test('Run button is displayed on Dashboard on Mac', async () => {
+    const runButtonText = await app.client
+      .$('button[data-testid=button-dashboard-run]')
+      .getText()
+
+    expect(runButtonText).toMatch('Run')
+  })
+
+  describe('All 5 test cards are visible on Mac', () => {
+    const testDetails = [
+      {
+        id: 'websites',
+        name: 'Websites',
+        desc: 'Test the blocking of websites',
+      },
+      {
+        id: 'im',
+        name: 'Instant Messaging',
+        desc: 'Test the blocking of instant messaging apps',
+      },
+      {
+        id: 'circumvention',
+        name: 'Circumvention',
+        desc: 'Test the blocking of censorship circumvention tools',
+      },
+      {
+        id: 'performance',
+        name: 'Performance',
+        desc: 'Test your network speed and performance',
+      },
+      {
+        id: 'middlebox',
+        name: 'Middleboxes',
+        desc: 'Detect middleboxes in your network',
+      },
+    ]
+
+    testDetails.forEach((itr) => {
+      test(`${itr.id} test card is visible on Mac`, async () => {
+        const isCardVisible = await app.client.isVisible(
+          `div[data-testid=run-card-${itr.id}]`
+        )
+        expect(isCardVisible).toBe(true)
+
+        const cardName = await app.client.getText(
+          `div[data-testid=run-card-${itr.id}] div[data-testid=run-card-name-${itr.id}]`
+        )
+        expect(cardName).toBe(itr.name)
+
+        const cardDesc = await app.client.getText(
+          `div[data-testid=run-card-${itr.id}] div[data-testid=run-card-description-${itr.id}]`
+        )
+        expect(cardDesc).toBe(itr.desc)
+      })
+    })
+  })
+
+  test('Loads up "Test Results" and opt-in for autorun on Mac', async () => {
+    await app.client
+      .$('div[data-testid=sidebar-item-test-results]')
+      .click()
+      .pause(500)
+
+    await app.client.waitUntilWindowLoaded()
+
+    await app.client.waitUntil(
+      async () =>
+        app.client.isVisible('div[data-testid=modal-autorun-confirmation]'),
+      30000
+    )
+
+    await expect(
+      app.client.getText('h4[data-testid=heading-autorun-confirmation]')
+    ).resolves.toMatch('Would you like to run tests automatically?')
+
+    await expect(
+      app.client.getText('h4[data-testid=text-autorun-confirmation]')
+    ).resolves.toMatch(
+      'By enabling automatic testing, OONI Probe tests will run automatically on a regular basis (and you don’t need to remember to manually run tests).'
+    )
+
+    await expect(
+      app.client.getText('button[data-testid=button-autorun-yes]')
+    ).resolves.toMatch('Sounds great')
+
+    await expect(
+      app.client.getText('button[data-testid=button-autorun-no]')
+    ).resolves.toMatch('No, thanks')
+
+    await expect(
+      app.client.getText('button[data-testid=button-autorun-yes]')
+    ).resolves.toMatch('Sounds great')
+
+    await app.client
+      .$('button[data-testid=button-autorun-yes]')
+      .click()
+      .pause(500)
+
+    const labelTests = await app.client
+      .$('div[data-testid=overview-tests]')
+      .getText()
+    const labelNetworks = await app.client
+      .$('div[data-testid=overview-networks]')
+      .getText()
+    const labelDataUsage = await app.client
+      .$('div[data-testid=overview-data-usage-label]')
+      .getText()
+
+    expect(labelTests).toContain('Tests')
+    expect(labelNetworks).toContain('Networks')
+    expect(labelDataUsage).toContain('Data Usage')
+
+    // screenshotApp(app, 'dashboard-test-results')
+  })
+
+  test('Loads up Settings page with autorun enabled on Mac', async () => {
+    await app.client
+      .$('div[data-testid=sidebar-item-settings]')
+      .click()
+      .pause(500)
+
+    await app.client.waitUntilWindowLoaded()
+
+    // Checking for the "Settings" heading
+    // Rest of the assertions are in settings.e2e.js
+    const labelTestOptionsVisible = await app.client.isVisible('h3=Settings')
+    expect(labelTestOptionsVisible).toBe(true)
+
+    await expect(
+      app.client.isSelected('input[data-testid=checkbox-autorun]')
+    ).resolves.toBeTruthy()
+
+    // screenshotApp(app, 'dashboard-settings-page')
+  })
+})
+
+describe.onWindows('Dashboard tests on Windows', () => {
+  let app
+
+  beforeAll(async () => {
+    app = await startApp()
+  })
+
+  afterAll(async () => {
+    await stopApp(app)
+  })
+
+  afterEach(async () => {
+    await screenshotApp(app, expect.getState().currentTestName)
+  })
+
+  test('Run button is displayed on Dashboard on Windows', async () => {
+    const runButtonText = await app.client
+      .$('button[data-testid=button-dashboard-run]')
+      .getText()
+
+    expect(runButtonText).toMatch('Run')
+  })
+
+  describe('All 5 test cards are visible on Windows', () => {
+    const testDetails = [
+      {
+        id: 'websites',
+        name: 'Websites',
+        desc: 'Test the blocking of websites',
+      },
+      {
+        id: 'im',
+        name: 'Instant Messaging',
+        desc: 'Test the blocking of instant messaging apps',
+      },
+      {
+        id: 'circumvention',
+        name: 'Circumvention',
+        desc: 'Test the blocking of censorship circumvention tools',
+      },
+      {
+        id: 'performance',
+        name: 'Performance',
+        desc: 'Test your network speed and performance',
+      },
+      {
+        id: 'middlebox',
+        name: 'Middleboxes',
+        desc: 'Detect middleboxes in your network',
+      },
+    ]
+
+    testDetails.forEach((itr) => {
+      test(`${itr.id} test card is visible on Windows`, async () => {
+        const isCardVisible = await app.client.isVisible(
+          `div[data-testid=run-card-${itr.id}]`
+        )
+        expect(isCardVisible).toBe(true)
+
+        const cardName = await app.client.getText(
+          `div[data-testid=run-card-${itr.id}] div[data-testid=run-card-name-${itr.id}]`
+        )
+        expect(cardName).toBe(itr.name)
+
+        const cardDesc = await app.client.getText(
+          `div[data-testid=run-card-${itr.id}] div[data-testid=run-card-description-${itr.id}]`
+        )
+        expect(cardDesc).toBe(itr.desc)
+      })
+    })
+  })
+
+  test('Loads up "Test Results" and opt-in for autorun on Windows', async () => {
+    await app.client
+      .$('div[data-testid=sidebar-item-test-results]')
+      .click()
+      .pause(500)
+
+    await app.client.waitUntilWindowLoaded()
+
+    await app.client.waitUntil(
+      async () =>
+        app.client.isVisible('div[data-testid=modal-autorun-confirmation]'),
+      30000
+    )
+
+    await expect(
+      app.client.getText('h4[data-testid=heading-autorun-confirmation]')
+    ).resolves.toMatch('Would you like to run tests automatically?')
+
+    await expect(
+      app.client.getText('h4[data-testid=text-autorun-confirmation]')
+    ).resolves.toMatch(
+      'By enabling automatic testing, OONI Probe tests will run automatically on a regular basis (and you don’t need to remember to manually run tests).'
+    )
+
+    await expect(
+      app.client.getText('button[data-testid=button-autorun-yes]')
+    ).resolves.toMatch('Sounds great')
+
+    await expect(
+      app.client.getText('button[data-testid=button-autorun-no]')
+    ).resolves.toMatch('No, thanks')
+
+    await expect(
+      app.client.getText('button[data-testid=button-autorun-yes]')
+    ).resolves.toMatch('Sounds great')
+
+    await app.client
+      .$('button[data-testid=button-autorun-yes]')
+      .click()
+      .pause(500)
+
+    const labelTests = await app.client
+      .$('div[data-testid=overview-tests]')
+      .getText()
+    const labelNetworks = await app.client
+      .$('div[data-testid=overview-networks]')
+      .getText()
+    const labelDataUsage = await app.client
+      .$('div[data-testid=overview-data-usage-label]')
+      .getText()
+
+    expect(labelTests).toContain('Tests')
+    expect(labelNetworks).toContain('Networks')
+    expect(labelDataUsage).toContain('Data Usage')
+
+    // screenshotApp(app, 'dashboard-test-results')
+  })
+
+  test('Loads up Settings page with autorun enabled on Windows', async () => {
+    await app.client
+      .$('div[data-testid=sidebar-item-settings]')
+      .click()
+      .pause(500)
+
+    await app.client.waitUntilWindowLoaded()
+
+    // Checking for the "Settings" heading
+    // Rest of the assertions are in settings.e2e.js
+    const labelTestOptionsVisible = await app.client.isVisible('h3=Settings')
+    expect(labelTestOptionsVisible).toBe(true)
+
+    await expect(
+      app.client.isSelected('input[data-testid=checkbox-autorun]')
+    ).resolves.toBeTruthy()
 
     // screenshotApp(app, 'dashboard-settings-page')
   })

--- a/test/lib/integration.config.js
+++ b/test/lib/integration.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   rootDir: '../../',
   testPathIgnorePatterns: ['/.next/', '/node_modules/'],
-  setupFilesAfterEnv: ['<rootDir>/test/lib/setupTests.js'],
+  setupFilesAfterEnv: ['jest-os-detection', '<rootDir>/test/lib/setupTests.js'],
   verbose: true,
   roots: ['<rootDir>/test', '<rootDir>/renderer'],
   testSequencer: '<rootDir>/test/lib/sequencer.js',

--- a/test/onboarding.e2e.js
+++ b/test/onboarding.e2e.js
@@ -10,7 +10,6 @@ describe('Onboarding Story 1', () => {
   })
 
   afterAll(async () => {
-    await resetData(app)
     await stopApp(app)
   })
 
@@ -173,6 +172,13 @@ describe('Onboarding Story 2', () => {
   let app
 
   beforeAll(async () => {
+    // Start app -> reset app -> close app
+    // ===> As a result, when the app starts up the next time,
+    //      it starts from the onboarding screen
+    app = await startApp()
+    await resetData(app)
+    await stopApp(app)
+
     app = await startApp()
   })
 

--- a/test/test-results.e2e.js
+++ b/test/test-results.e2e.js
@@ -1,4 +1,4 @@
-import { startApp, stopApp, screenshotApp } from './utils'
+import { startApp, stopApp, screenshotApp, resetData } from './utils'
 
 jest.setTimeout(600000)
 
@@ -19,6 +19,7 @@ describe('Tests for Test-Results screen', () => {
   })
 
   afterAll(async () => {
+    await resetData(app)
     await stopApp(app)
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9481,6 +9481,11 @@ jest-mock@^25.4.0:
   dependencies:
     "@jest/types" "^25.4.0"
 
+jest-os-detection@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jest-os-detection/-/jest-os-detection-1.3.1.tgz#fad89c4de675bc3cfd07f630a132fe5d82563d01"
+  integrity sha512-1epFqoue/1J8f9SHOegDE4mY9kJBpetcZAeWtB0SG4XjtkI252mOu4TLJMjl1hDb7v6VefKPeWUweu/TsR7ZcQ==
+
 jest-pnp-resolver@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"


### PR DESCRIPTION
* Onboarding Story 1 and 2 now made independent
* Autorun prompt covered in tests for MacOS and Windows
* App now resets data after final e2e test is performed, so it doesn't fail every alternate time.