### PR TITLE
Release 3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OONI Probe Desktop app",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
-  "version": "3.6.1-rc.1",
+  "version": "3.6.1",
   "probeVersion": "3.10.0-beta.3",
   "main": "main/index.js",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## OONI Probe Desktop 3.6.1 [2021-10-21]

probe-cli: 3.10.0-beta.3

### Fixed 
- Fixed [bug](ooni/probe#1834) that caused showing "Experimental" when running "Websites" tests. #257 
