### PR TITLE
chore: use ooniprobe-cli 3.11.0-beta.2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,8 @@ In order to start hacking on this, we assume you have `node` and `yarn`
 installed.
 
 Then you can run:
-```
+
+```bash
 yarn install
 ```
 
@@ -65,9 +66,9 @@ yarn run start
 
 ## Update the translations
 
-* Save the strings from the canonical spreadsheet into `data/lang-en.csv`
-* Run `$ node scripts/update-translations.js`
-* Commit `data/lang-en.csv`, `lang/*.json` and `renderer/static/translations.js`
+- Save the strings from the canonical spreadsheet into `data/lang-en.csv`
+- Run `$ node scripts/update-translations.js`
+- Commit `data/lang-en.csv`, `lang/*.json` and `renderer/static/translations.js`
 into git
 
 ## Build and sign macOS app
@@ -91,7 +92,7 @@ OONI_TEAMID=YWCG8FZTLT
 where `TOKEN` is a [personal github token](https://github.com/settings/tokens/new)
 with repository scope, `your@apple.id` is the Apple ID you are using as part of our
 team, `XXXX` is a password specific application created by visiting
-https://appleid.apple.com and logging in as `your@apple.id`, and
+[appleid.apple.com](https://appleid.apple.com) and logging in as `your@apple.id`, and
 `YWCG8FZTLT` is the team ID used by OONI.
 
 Then, run:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.6.1",
-  "probeVersion": "3.10.0-beta.3",
+  "probeVersion": "3.11.0-beta.2",
   "main": "main/index.js",
   "license": "BSD-3-Clause",
   "repository": "ooni/probe-desktop",

--- a/scripts/download-bin.js
+++ b/scripts/download-bin.js
@@ -13,28 +13,24 @@ const dstDir = path.join(appRoot, 'build', 'probe-cli')
 
 const download = () => {
   ensureDirSync(dstDir)
-  const osarchlist = ['darwin_amd64', 'linux_amd64', 'windows_amd64']
-  for (let i = 0; i < osarchlist.length; i += 1) {
-    const osarch = osarchlist[i]
-    const tarball = `ooniprobe_${osarch}.tar.gz`
-    const tarballURL = `${baseURL}/${tarball}`
-    const sig = `${tarball}.asc`
-    const sigURL = `${tarballURL}.asc`
-    if (existsSync(`${dstDir}/${tarball}`) === false) {
-      console.log(`Downloading ${tarball}`)
-      execSync(`curl -#f -L -o ${dstDir}/${tarball} ${tarballURL}`)
+  const osarchs = [
+    "darwin-amd64",
+    "linux-amd64",
+    "windows-amd64",
+  ]
+  for (let i = 0; i < osarchs.length; i += 1) {
+    const extension = (osarchs[i] === "windows-amd64") ? ".exe" : ""
+    const filename = "ooniprobe-" + osarchs[i] + extension
+    const fileURL = `${baseURL}/${filename}`
+    const versionedFilename = probeVersion + "__" + filename
+    if (existsSync(`${dstDir}/${versionedFilename}`) === false) {
+      console.log(`download ${versionedFilename}`)
+      execSync(`curl -#f -L -o ${dstDir}/${versionedFilename} ${fileURL}`)
     }
-    if (existsSync(`${dstDir}/${sig}`) === false) {
-      console.log(`Downloading ${sig}`)
-      execSync(`curl -#f -L -o ${dstDir}/${sig} ${sigURL}`)
-    }
-    try {
-      execSync(`gpg --quiet --verify ${dstDir}/${sig} ${dstDir}/${tarball}`)
-    } catch (e) {
-      console.error(`Signature verification failure: ${e}`)
-    }
+    const osarch = osarchs[i].replace("-", "_")
     ensureDirSync(`${dstDir}/${osarch}`)
-    execSync(`cd ${dstDir}/${osarch} && tar xzf ../${tarball}`)
+    execSync(`cp ${dstDir}/${versionedFilename} ${dstDir}/${osarch}/ooniprobe${extension}`)
+    execSync(`chmod +x ${dstDir}/${osarch}/ooniprobe${extension}`)
   }
 }
 

--- a/scripts/download-bin.js
+++ b/scripts/download-bin.js
@@ -14,20 +14,21 @@ const dstDir = path.join(appRoot, 'build', 'probe-cli')
 const download = () => {
   ensureDirSync(dstDir)
   const osarchs = [
-    "darwin-amd64",
-    "linux-amd64",
-    "windows-amd64",
+    'darwin-amd64',
+    'linux-amd64',
+    'windows-amd64',
   ]
-  for (let i = 0; i < osarchs.length; i += 1) {
-    const extension = (osarchs[i] === "windows-amd64") ? ".exe" : ""
-    const filename = "ooniprobe-" + osarchs[i] + extension
+  var osarch
+  for (osarch of osarchs) {
+    const extension = osarch.includes('windows') ? '.exe' : ''
+    const filename = `ooniprobe-${osarch}${extension}`
     const fileURL = `${baseURL}/${filename}`
-    const versionedFilename = probeVersion + "__" + filename
+    const versionedFilename = `${probeVersion}__${filename}`
     if (existsSync(`${dstDir}/${versionedFilename}`) === false) {
       console.log(`download ${versionedFilename}`)
       execSync(`curl -#f -L -o ${dstDir}/${versionedFilename} ${fileURL}`)
     }
-    const osarch = osarchs[i].replace("-", "_")
+    osarch = osarch.replace('-', '_')
     ensureDirSync(`${dstDir}/${osarch}`)
     execSync(`cp ${dstDir}/${versionedFilename} ${dstDir}/${osarch}/ooniprobe${extension}`)
     execSync(`chmod +x ${dstDir}/${osarch}/ooniprobe${extension}`)


### PR DESCRIPTION
This diff changes ooniprobe-desktop to use cli v3.11.0-beta.2.

This cli release includes changes in the last (at this point six!)
months to improve measurements quality.

It is missing some extra fixes required to bless a stable
release. Chiefly among them, the possiblity of running
cleanly the DNSCheck experiment.

I'm going to work on these issues as soon as possible.

In the meanwhile, this release is a good testing base to check
whether we have additional lingering issues.

A few notes to explain this diff follows.

First, I took the liberty of reducing as much as possible
the amount of markdown linting warning I did see.

Second, 3.11.0-beta.2 is the first release that is fully built
using the cloud. I have not added any PGP key to the cloud
as this seems a bit futile. Maybe it is not and maybe I'm not
seeing the full picture, so we should discuss this topic. (I
would not put my PGP key in there, and instead I'd put another
key that has no password to sign releases; is this better
than not using any key at all?)

Third, cloud builds do not use tar.gz anymore. I did this to
work around https://github.com/ooni/probe/issues/1884 (in general,
less pieces we use, less errors could occur.)

As a result, the download script needed a bit of reworking.

Fourth, while I reckon this is unlikely, I couldn't help noticing
that the previous script did not download in case files were
already on disk. To add a bit of robustness to this process, I
am now prefixing the downloaded file with its version. This way,
we'll re-download if there is a cli version change and there
are already files on disk and, by some other mistake, the build
rules are such that we don't clean existing files.

The related issue is https://github.com/ooni/probe/issues/1879