### PR TITLE
feat: use ooni/probe-cli 3.13.0 and expose dnscheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.6.1",
-  "probeVersion": "3.13.0-beta",
+  "probeVersion": "3.13.0",
   "main": "main/index.js",
   "license": "BSD-3-Clause",
   "repository": "ooni/probe-desktop",

--- a/renderer/components/nettests/index.js
+++ b/renderer/components/nettests/index.js
@@ -74,6 +74,7 @@ export const tests = {
   riseupvpn,
   signal,
   stunreachability: minimalTest('stunreachability'),
+  dnscheck: minimalTest('dnscheck'),
   'default': {
     'name': 'Default',
   }


### PR DESCRIPTION
This diff uses ooni/probe-cli 3.13.0. I tested that this
specific version was working in linux/amd64.

While there, I noticed that dnscheck was not exposed,
for understandable reasons (it has been broken until the
release of 3.13.0) and exposed it. (It has been quite a
pleasing experience to be able to expose it by just
adding a single line of code for declaring it, well done!)

Reference issue https://github.com/ooni/probe/issues/1843