### PR TITLE
Fix RiseupVPN result screen issue

### DIFF
--- a/renderer/components/nettests/circumvention/RiseupVPN.js
+++ b/renderer/components/nettests/circumvention/RiseupVPN.js
@@ -46,14 +46,13 @@ const RiseupVPN = ({measurement, isAnomaly, render, rawData}) => {
     let failedBridgeGateways = 0
 
     if (rawData) {
-      const failingGateways = rawData.test_keys.failing_gateways
+      const failingGateways = rawData?.test_keys?.failing_gateways
       if (failingGateways && Array.isArray(failingGateways)) {
         for (const gateway of failingGateways) {
           const { transport_type = '' } = gateway
           if (transport_type === 'openvpn') {
             failedOpenVPNGateways++
-          }
-          if (transport_type === 'obfs4') {
+          } else if (transport_type === 'obfs4') {
             failedBridgeGateways++
           }
         }

--- a/renderer/components/nettests/performance/NDT.js
+++ b/renderer/components/nettests/performance/NDT.js
@@ -32,7 +32,7 @@ const NDT = ({measurement, render}) => {
   const server = useMemo(() => {
     try {
       if (rawData) {
-        if (rawData.test_keys.server.hostname) {
+        if (rawData?.test_keys?.server?.hostname) {
           return rawData.test_keys.server.hostname
         }
       } else {

--- a/renderer/components/useRawData.js
+++ b/renderer/components/useRawData.js
@@ -7,12 +7,12 @@ import Raven from 'raven-js'
 export const useRawData = (msmtID = null) => {
   const [rawData, setRawData] = React.useState(null)
   const [error, setError] = React.useState(null)
+  const { query } = useRouter()
 
   const remote = electron.remote
   const { showMeasurement } = remote.require('./actions')
 
   if (!msmtID) {
-    const { query } = useRouter()
     msmtID = query.measurementID
   }
 


### PR DESCRIPTION
Fixes ooni/probe#1953

When the output of `ooniprobe show <id>` fails to return a valid measurement in response, the pages that consume parts of the raw measurement were crashing. This PR fixes that.

First noticed for certain `riseupvpn` tests recently. Fix applied to other places with similar usage.