### PR TITLE
Fix conflict with probe-cli in using max_runtime

### DIFF
--- a/renderer/components/settings/widgets.js
+++ b/renderer/components/settings/widgets.js
@@ -28,15 +28,18 @@ const StyledErrorMessage = styled(Box).attrs({
   color: ${props => props.theme.colors.red5};
 `
 
-export const BooleanOption = ({ label, optionKey, disabled = false, ...rest }) => {
+export const BooleanOption = ({ label, optionKey, disabled = false, onChange, ...rest }) => {
   const [checked, setConfigValue] = useConfig(optionKey)
 
   const handleChange = useCallback((event) => {
     const target = event.target
     const newValue = Boolean(target.type === 'checkbox' ? target.checked : target.value)
+    if (typeof onChange === 'function') {
+      onChange(newValue)
+    }
 
     setConfigValue(newValue)
-  }, [setConfigValue])
+  }, [setConfigValue, onChange])
 
   return (
     <StyledLabel my={2} disabled={disabled} alignItems='center'>

--- a/renderer/pages/settings.js
+++ b/renderer/pages/settings.js
@@ -82,14 +82,14 @@ const Settings = () => {
                 optionKey='nettests.websites_enable_max_runtime'
                 onChange={syncMaxRuntimeWidgets}
               />
-              <NumberOption
+              {maxRuntimeEnabled && <NumberOption
                 key={maxRuntime} /* Used to re-render widget when value changes in `syncMaxRuntimeWidgets()` */
                 label={<FormattedMessage id='Settings.Websites.MaxRuntime' />}
                 optionKey='nettests.websites_max_runtime'
                 min={60}
                 max={999}
                 disabled={!maxRuntimeEnabled}
-              />
+              />}
             </Section>
             {/* Autorun */}
             <Section title={<FormattedMessage id='Settings.AutomatedTesting.Label' />}>

--- a/renderer/pages/settings.js
+++ b/renderer/pages/settings.js
@@ -45,10 +45,17 @@ Section.propTypes = {
 }
 
 const Settings = () => {
-  const [config, /*setConfig, loading, err*/] = useConfig()
-  const maxRuntimeEnabled = useMemo(() => {
-    return config ? config.nettests.websites_enable_max_runtime : undefined
-  }, [config])
+  const [maxRuntimeEnabled] = useConfig('nettests.websites_enable_max_runtime')
+  const [/* maxRuntime */, setMaxRuntime] = useConfig('nettests.websites_max_runtime')
+
+  // This keeps the values of websites_enable_max_runtime(bool) and websites_max_runtime (number)
+  // in sync. Withtout this, `probe-cli` continues to use the number in `websites_max_runtime`
+  // even if `websites_enable_max_runtime` is false (unchecked).
+  const syncMaxRuntimeWidgets = (newValue) => {
+    if (newValue === false) {
+      setMaxRuntime(0)
+    }
+  }
 
   return (
     <Layout>
@@ -71,6 +78,7 @@ const Settings = () => {
               <BooleanOption
                 label={<FormattedMessage id='Settings.Websites.MaxRuntimeEnabled' />}
                 optionKey='nettests.websites_enable_max_runtime'
+                onChange={syncMaxRuntimeWidgets}
               />
               <NumberOption
                 label={<FormattedMessage id='Settings.Websites.MaxRuntime' />}

--- a/renderer/pages/settings.js
+++ b/renderer/pages/settings.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { useMemo } from 'react'
+import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import styled from 'styled-components'
 import {
@@ -46,7 +46,7 @@ Section.propTypes = {
 
 const Settings = () => {
   const [maxRuntimeEnabled] = useConfig('nettests.websites_enable_max_runtime')
-  const [/* maxRuntime */, setMaxRuntime] = useConfig('nettests.websites_max_runtime')
+  const [maxRuntime, setMaxRuntime] = useConfig('nettests.websites_max_runtime')
 
   // This keeps the values of websites_enable_max_runtime(bool) and websites_max_runtime (number)
   // in sync. Withtout this, `probe-cli` continues to use the number in `websites_max_runtime`
@@ -54,6 +54,8 @@ const Settings = () => {
   const syncMaxRuntimeWidgets = (newValue) => {
     if (newValue === false) {
       setMaxRuntime(0)
+    } else {
+      setMaxRuntime(90)
     }
   }
 
@@ -81,6 +83,7 @@ const Settings = () => {
                 onChange={syncMaxRuntimeWidgets}
               />
               <NumberOption
+                key={maxRuntime} /* Used to re-render widget when value changes in `syncMaxRuntimeWidgets()` */
                 label={<FormattedMessage id='Settings.Websites.MaxRuntime' />}
                 optionKey='nettests.websites_max_runtime'
                 min={60}


### PR DESCRIPTION
probe-desktop uses `nettests.websites_enable_max_runtime` from the config and ignores `nettests.websites_max_runtime` when running websites card.

Whereas probe-cli always uses `nettests.websites_max_runtime` (unless it is `0`) to limit the runtime.

This means even if it is disabled in the desktop UI, runtimes are still limited by `probe-cli` because it sees a non-zero value in `config.json`.

The currently proposed solution forces `nettests.websites_max_runtime` to `0` when it is disabled. This loses our ability to remember if the user had previously set a custom duration before disabling.

One way to overcome that would be to store that value in `settings.json` and retrieve it. But I think that adds unnecessaryredundancy.

The ideal solution is probably to move all `probe-desktop` settings to `settings.json` and use it to generate a `config.<timestamp>.json` whenever probe-cli is launched.
