### PR TITLE
Properly sync config values for max_runtime

### DIFF
--- a/main/ipcBindings.js
+++ b/main/ipcBindings.js
@@ -262,8 +262,15 @@ const ipcBindingsForMain = (ipcMain) => {
   })
 
   ipcMain.handle('config.set', async (event, key, currentValue, value) => {
-    // const config = await getConfig()
-    // const currentValue = key.split('.').reduce((o,i) => o[i], config)
+    // This keeps the values of websites_enable_max_runtime(bool) and websites_max_runtime (number)
+    // in sync. Withtout this, `probe-cli` continues to use the number in `websites_max_runtime`
+    // even if `websites_enable_max_runtime` is false (unchecked).
+    if (key === 'nettests.websites_enable_max_runtime') {
+      const maxRuntimeCurrentValue = await getConfig('nettests.websites_max_runtime')
+      const maxRuntimeNewValue = value === true ? 90 : 0
+      await setConfig('nettests.websites_max_runtime', maxRuntimeCurrentValue, maxRuntimeNewValue)
+    }
+
     const newConfig = await setConfig(key, currentValue, value)
     return newConfig
   })

--- a/renderer/pages/settings.js
+++ b/renderer/pages/settings.js
@@ -46,18 +46,6 @@ Section.propTypes = {
 
 const Settings = () => {
   const [maxRuntimeEnabled] = useConfig('nettests.websites_enable_max_runtime')
-  const [maxRuntime, setMaxRuntime] = useConfig('nettests.websites_max_runtime')
-
-  // This keeps the values of websites_enable_max_runtime(bool) and websites_max_runtime (number)
-  // in sync. Withtout this, `probe-cli` continues to use the number in `websites_max_runtime`
-  // even if `websites_enable_max_runtime` is false (unchecked).
-  const syncMaxRuntimeWidgets = (newValue) => {
-    if (newValue === false) {
-      setMaxRuntime(0)
-    } else {
-      setMaxRuntime(90)
-    }
-  }
 
   return (
     <Layout>
@@ -80,10 +68,8 @@ const Settings = () => {
               <BooleanOption
                 label={<FormattedMessage id='Settings.Websites.MaxRuntimeEnabled' />}
                 optionKey='nettests.websites_enable_max_runtime'
-                onChange={syncMaxRuntimeWidgets}
               />
               {maxRuntimeEnabled && <NumberOption
-                key={maxRuntime} /* Used to re-render widget when value changes in `syncMaxRuntimeWidgets()` */
                 label={<FormattedMessage id='Settings.Websites.MaxRuntime' />}
                 optionKey='nettests.websites_max_runtime'
                 min={60}


### PR DESCRIPTION
Fixes ooni/probe#2046

There was a race condition with asynchronously writing the values for `nettests.websites_enable_max_runtime` and `nettests.websites_max_runtime`.

In this fix, the functionality is moved to the main process, particularly in the IPC event handler for `config.set` which returns only after synchronously writing the dependent value first. The return value contains the full config with both changes and updates the `ConfigContext` accordingly.
