### PR TITLE
Do not initialize Sentry before initializing config

### DIFF
--- a/main/utils/config.js
+++ b/main/utils/config.js
@@ -1,7 +1,6 @@
 const path = require('path')
 const fs = require('fs-extra')
 const log = require('electron-log')
-const Sentry = require('./sentry')
 
 const { getHomeDir, getAutorunHomeDir } = require('./paths')
 
@@ -83,6 +82,7 @@ const initConfigFile = async (options = {}) => {
   await fs.writeJson(opts.configFilePath, config, {spaces: '  '})
 
   // Now that a config file is available, let's try to initialize Sentry again
+  const Sentry = require('./sentry')
   Sentry()
 }
 


### PR DESCRIPTION
There was a circular dependency requiring the modules `main/utils/sentry.js` and `main/utils/config.js` from `main/index.js`. This fix breaks it by lazily loading one of the modules when needed.