### PR TITLE
Fix font flickering on page load

### DIFF
--- a/renderer/components/IntlProvider.js
+++ b/renderer/components/IntlProvider.js
@@ -4,9 +4,6 @@ import { createIntl, createIntlCache, RawIntlProvider } from 'react-intl'
 import { getMessages, getLocale } from '../components/langUtils'
 import { useConfig } from '../components/settings/useConfig'
 import moment from 'moment'
-// Polyfill Intl.DisplayNames to display language names in the selected language
-import '@formatjs/intl-displaynames/polyfill'
-require('@formatjs/intl-displaynames/locale-data/en')
 
 // This is optional but highly recommended
 // since it prevents memory leak
@@ -44,14 +41,11 @@ const IntlProvider = ({ children }) => {
 
   const [activeLang, activateLang] = useState(languageConfig || systemLocale || 'en')
 
-  require(`@formatjs/intl-displaynames/locale-data/${activeLang}`)
-
   const messages = getMessages(activeLang)
 
   const intl = createIntl({ locale: activeLang, messages }, cache)
 
   const changeLocale = (locale) => {
-    require(`@formatjs/intl-displaynames/locale-data/${locale}`)
     activateLang(locale)
     // HACK: We strip `zh-TW` to `zh` which is not recognized by momentjs
     moment.locale(locale === 'zh' ? 'zh-TW' : locale)

--- a/renderer/components/global.css
+++ b/renderer/components/global.css
@@ -1,0 +1,62 @@
+@font-face {
+  font-family: "Fira Sans";
+  src: url('/static/fonts/FiraSans-Light.woff') format('woff');
+  font-style: normal;
+  font-weight: 300;
+}
+
+@font-face {
+  font-family: "Fira Sans";
+  src: url('/static/fonts/FiraSans-Regular.woff') format('woff');
+  font-style: normal;
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: "Fira Sans";
+  src: url('/static/fonts/FiraSans-Italic.woff') format('woff');
+  font-style: italic;
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: "Fira Sans";
+  src: url('/static/fonts/FiraSans-SemiBold.woff') format('woff');
+  font-style: normal;
+  font-weight: 600;
+}
+
+@font-face {
+  font-family: "Fira Sans";
+  src: url('/static/fonts/FiraSans-Bold.woff') format('woff');
+  font-style: normal;
+  font-weight: 700;
+}
+
+@font-face {
+  font-family: "Source Code Pro";
+  src: url('/static/fonts/SourceCodePro-Regular.woff') format('woff');
+  font-style: normal;
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: "Source Code Pro";
+  src: url('/static/fonts/SourceCodePro-Bold.woff') format('woff');
+  font-style: normal;
+  font-weight: 700;
+}
+
+@font-face {
+  font-family: "Charter";
+  src: url('/static/fonts/Charter-Regular.woff') format('woff');
+  font-style: normal;
+  font-weight: 300;
+}
+
+@font-face {
+  font-family: "Charter";
+  src: url('/static/fonts/Charter-Bold.woff') format('woff');
+  font-style: normal;
+  font-weight: 700;
+}

--- a/renderer/components/globalStyle.js
+++ b/renderer/components/globalStyle.js
@@ -1,86 +1,11 @@
 import { createGlobalStyle } from 'styled-components'
 
-const CharterRegular = '/static/fonts/Charter-Regular.woff'
-const CharterBold = '/static/fonts/Charter-Bold.woff'
-
-const FiraSansLight = '/static/fonts/FiraSans-Light.woff'
-const FiraSansRegular = '/static/fonts/FiraSans-Regular.woff'
-const FiraSansItalic = '/static/fonts/FiraSans-Italic.woff'
-const FiraSansBold = '/static/fonts/FiraSans-Bold.woff'
-const FiraSansSemiBold = '/static/fonts/FiraSans-SemiBold.woff'
-
-const SourceCodeProBold = '/static/fonts/SourceCodePro-Bold.woff'
-const SourceCodeProRegular = '/static/fonts/SourceCodePro-Regular.woff'
-
 const GlobalStyle = createGlobalStyle`
   body, html {
     direction: ltr; /* this is flipped by stylis-plugin-rtl */
     margin: 0;
-    font-family: "Fira Sans";
+    font-family: "Fira Sans", sans-serif;
     -webkit-font-smoothing: antialiased;
-  }
-
-  @font-face {
-    font-family: "Fira Sans";
-    src: url('${FiraSansLight}') format('woff');
-    font-style: normal;
-    font-weight: 300;
-  }
-
-  @font-face {
-    font-family: "Fira Sans";
-    src: url('${FiraSansRegular}') format('woff');
-    font-style: normal;
-    font-weight: 400;
-  }
-
-  @font-face {
-    font-family: "Fira Sans";
-    src: url('${FiraSansItalic}') format('woff');
-    font-style: italic;
-    font-weight: 400;
-  }
-
-  @font-face {
-    font-family: "Fira Sans";
-    src: url('${FiraSansSemiBold}') format('woff');
-    font-style: normal;
-    font-weight: 600;
-  }
-
-  @font-face {
-    font-family: "Fira Sans";
-    src: url('${FiraSansBold}') format('woff');
-    font-style: normal;
-    font-weight: 700;
-  }
-
-  @font-face {
-    font-family: "Source Code Pro";
-    src: url('${SourceCodeProRegular}') format('woff');
-    font-style: normal;
-    font-weight: 400;
-  }
-
-  @font-face {
-    font-family: "Source Code Pro";
-    src: url('${SourceCodeProBold}') format('woff');
-    font-style: normal;
-    font-weight: 700;
-  }
-
-  @font-face {
-    font-family: "Charter";
-    src: url('${CharterRegular}') format('woff');
-    font-style: normal;
-    font-weight: 300;
-  }
-
-  @font-face {
-    font-family: "Charter";
-    src: url('${CharterBold}') format('woff');
-    font-style: normal;
-    font-weight: 700;
   }
 `
 

--- a/renderer/pages/_app.js
+++ b/renderer/pages/_app.js
@@ -2,6 +2,7 @@ import React from 'react'
 import log from 'electron-log'
 import IntlProvider from '../components/IntlProvider'
 import { ConfigProvider } from '../components/settings/useConfig'
+import '../components/global.css'
 
 log.transports.console.level = process.env.NODE_ENV === 'development' ? 'debug' : 'info'
 log.transports.file.level = 'debug'

--- a/renderer/pages/_document.js
+++ b/renderer/pages/_document.js
@@ -2,27 +2,37 @@ import React from 'react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 
-import '../components/globalStyle'
-
-class CustomDocument extends Document {
-  static getInitialProps ({ renderPage }) {
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx) {
     const sheet = new ServerStyleSheet()
-    const page = renderPage(App => props =>
-      sheet.collectStyles(
-        <App {...props} />
-      )
-    )
-    const styleTags = sheet.getStyleElement()
-    const props = { ...page, styleTags }
-    return props
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: (
+          <>
+            {initialProps.styles}
+            {sheet.getStyleElement()}
+          </>
+        ),
+      }
+    } finally {
+      sheet.seal()
+    }
   }
 
   render () {
     return (
       <Html>
-        <Head>
-          {this.props.styleTags}
-        </Head>
+        <Head />
         <body>
           <div className='root'>
             <Main />
@@ -34,5 +44,3 @@ class CustomDocument extends Document {
     )
   }
 }
-
-export default CustomDocument


### PR DESCRIPTION
Fixes ooni/probe#2045
Fixes ooni/probe#1279

Reference issues for font glitch: https://github.com/vercel/next.js/issues/22001 https://github.com/vercel/next.js/issues/18769

This also stops loading unnecessary polyfill for Intl.DisplayNames which reduces the file size of exported pages by ~5mb each.
