### PR TITLE
desktop: use probe-cli v3.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.8.0-dev",
-  "probeVersion": "3.15.0-alpha.1",
+  "probeVersion": "3.15.1",
   "main": "main/index.js",
   "license": "BSD-3-Clause",
   "repository": "ooni/probe-desktop",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.8.0-dev",
-  "probeVersion": "3.15.0-alpha",
+  "probeVersion": "3.15.0-alpha.1",
   "main": "main/index.js",
   "license": "BSD-3-Clause",
   "repository": "ooni/probe-desktop",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.8.0-dev",
-  "probeVersion": "3.14.1",
+  "probeVersion": "3.15.0-alpha",
   "main": "main/index.js",
   "license": "BSD-3-Clause",
   "repository": "ooni/probe-desktop",


### PR DESCRIPTION
This pull request adds support for using probe-cli v3.15.1 along with the desktop app.

See https://github.com/ooni/probe/issues/2100.