### PR TITLE
chore: update to ooni/probe-cli@v3.17.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.9.0",
-  "probeVersion": "3.17.2",
+  "probeVersion": "3.17.4",
   "main": "main/index.js",
   "license": "BSD-3-Clause",
   "repository": "ooni/probe-desktop",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OONI Probe Desktop app",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
-  "version": "3.9.1-rc.1",
+  "version": "3.9.1",
   "probeVersion": "3.17.5",
   "main": "main/index.js",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
   "version": "3.9.0",
-  "probeVersion": "3.17.4",
+  "probeVersion": "3.17.5",
   "main": "main/index.js",
   "license": "BSD-3-Clause",
   "repository": "ooni/probe-desktop",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "OONI Probe Desktop app",
   "author": "Open Observatory of Network Interference (OONI) <contact@openobservatory.org>",
   "productName": "OONI Probe",
-  "version": "3.9.0",
+  "version": "3.9.1-rc.1",
   "probeVersion": "3.17.5",
   "main": "main/index.js",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
This diff updates to probe-cli@v3.17.5.

Related issue: https://github.com/ooni/probe/issues/2485.