### PR TITLE
Sign ooniprobe.exe during build

### DIFF
--- a/scripts/download-probe-cli.js
+++ b/scripts/download-probe-cli.js
@@ -13,11 +13,7 @@ const dstDir = path.join(appRoot, 'build', 'probe-cli')
 
 const download = () => {
   ensureDirSync(dstDir)
-  const osarchs = [
-    'darwin-amd64',
-    'linux-amd64',
-    'windows-amd64',
-  ]
+  const osarchs = ['darwin-amd64', 'linux-amd64', 'windows-amd64']
   var osarch
   for (osarch of osarchs) {
     const extension = osarch.includes('windows') ? '.exe' : ''
@@ -30,7 +26,19 @@ const download = () => {
     }
     osarch = osarch.replace('-', '_')
     ensureDirSync(`${dstDir}/${osarch}`)
-    execSync(`cp ${dstDir}/${versionedFilename} ${dstDir}/${osarch}/ooniprobe${extension}`)
+    if (osarch === 'windows_amd64') {
+      execSync(
+        `cp ${dstDir}/${versionedFilename} ${dstDir}/${osarch}/ooniprobe${extension}-unsigned`
+      )
+      execSync(
+        `osslsigncode sign -pkcs12 ${process.env.WIN_CSC_LINK} -pass ${process.env.WIN_CSC_KEY_PASSWORD} -n "OONI Probe CLI" -i https://ooni.org/ -in ${dstDir}/${osarch}/ooniprobe${extension}-unsigned -out ${dstDir}/${osarch}/ooniprobe${extension}`
+      )
+      execSync(`rm -rf ${dstDir}/${osarch}/ooniprobe${extension}-unsigned`)
+    } else {
+      execSync(
+        `cp ${dstDir}/${versionedFilename} ${dstDir}/${osarch}/ooniprobe${extension}`
+      )
+    }
     execSync(`chmod +x ${dstDir}/${osarch}/ooniprobe${extension}`)
   }
 }


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2683

I was able to reproduce the issue with windows 11 running on UTM. Windows Defender also raised an alarm when downloading unsigned ooniprobe.exe on it's own - also marking it as a Trojan.

Probe desktop with signed ooniprobe.exe is working as expected on my UTM instance.